### PR TITLE
Task #20: remove auth token response body for cookie-auth flows

### DIFF
--- a/TESTPLAN.md
+++ b/TESTPLAN.md
@@ -11,7 +11,8 @@ Test case definitions for Quaero. Tests are defined here before implementation. 
 ### Happy Path
 
 - POST /api/auth/register with valid username, email, password returns 201 and user object
-- POST /api/auth/login with valid credentials returns 200 and JWT token
+- POST /api/auth/login with valid credentials returns 200 and JSON body with `csrf_token` (no auth tokens in body)
+- POST /api/auth/refresh with valid refresh credential returns 200 and JSON body with `csrf_token` (no auth tokens in body)
 - GET /api/auth/me with valid token returns current user data
 - Password is hashed (not stored as plaintext) in database
 

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -65,9 +65,8 @@ async def login(
     """
     Login with username and password.
 
-    Returns a short-lived access token JWT and a long-lived refresh token
-    in both the JSON body and as httpOnly cookies. Existing clients that
-    read from the body continue to work unchanged.
+    Sets access/refresh tokens in httpOnly cookies and returns only
+    browser-safe fields in the JSON body.
     """
     db_user = await get_user_by_username(db, user.username)
     if not db_user:
@@ -90,7 +89,7 @@ async def login(
     # clients that cannot read a cookie set on a different origin (see ADR-001).
     csrf_value = set_auth_cookies(response, access_token, refresh_token)
 
-    return {"access_token": access_token, "refresh_token": refresh_token, "csrf_token": csrf_value, "token_type": "bearer"}
+    return {"csrf_token": csrf_value, "token_type": "bearer"}
 
 
 @router.post("/refresh", response_model=Token)
@@ -137,7 +136,7 @@ async def refresh(
     # Rotate cookies; return fresh csrf_token in body for cross-domain clients.
     csrf_value = set_auth_cookies(response, access_token, new_refresh_token)
 
-    return {"access_token": access_token, "refresh_token": new_refresh_token, "csrf_token": csrf_value, "token_type": "bearer"}
+    return {"csrf_token": csrf_value, "token_type": "bearer"}
 
 
 @router.post("/logout")

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -31,10 +31,8 @@ class UserResponse(BaseModel):
 
 
 class Token(BaseModel):
-    """Token pair returned on login and token refresh."""
+    """Auth response payload for login and refresh."""
 
-    access_token: str
-    refresh_token: str
     csrf_token: str  # returned in body for cross-domain clients (see ADR-001)
     token_type: str = "bearer"
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -157,7 +157,9 @@ class TestRegister:
 class TestLogin:
     """POST /api/auth/login"""
 
-    async def test_login_returns_token_with_valid_credentials(self, client, test_user: User):
+    async def test_login_hides_auth_tokens_in_response_body(
+        self, client, test_user: User
+    ):
         response = await client.post(
             "/api/auth/login",
             json={"username": test_user.username, "password": TEST_PASSWORD},
@@ -165,11 +167,11 @@ class TestLogin:
 
         assert response.status_code == 200
         data = response.json()
-        assert "access_token" in data
-        assert "refresh_token" in data
+        assert "access_token" not in data
+        assert "refresh_token" not in data
+        assert "csrf_token" in data
         assert data["token_type"] == "bearer"
-        assert len(data["access_token"]) > 0
-        assert len(data["refresh_token"]) == 64  # secrets.token_hex(32)
+        assert len(data["csrf_token"]) > 0
 
     async def test_login_returns_401_with_wrong_username(self, client):
         response = await client.post(
@@ -220,12 +222,13 @@ class TestLoginStoresRefreshToken:
     async def test_login_stores_refresh_token_in_db(
         self, client: AsyncClient, db_session: AsyncSession, test_user: User
     ):
-        """The refresh token returned by login must exist in the DB."""
+        """The refresh token cookie issued by login must exist in the DB."""
         response = await client.post(
             "/api/auth/login",
             json={"username": test_user.username, "password": TEST_PASSWORD},
         )
-        refresh_token = response.json()["refresh_token"]
+        refresh_token = response.cookies.get("refresh_token")
+        assert refresh_token is not None
 
         row = await db_session.scalar(
             select(RefreshToken).where(RefreshToken.token == refresh_token)
@@ -237,7 +240,7 @@ class TestLoginStoresRefreshToken:
 class TestRefresh:
     """POST /api/auth/refresh"""
 
-    async def test_refresh_returns_new_token_pair_with_valid_token(
+    async def test_refresh_hides_auth_tokens_in_response_body(
         self, client: AsyncClient, refresh_token_str: str
     ):
         response = await client.post(
@@ -247,11 +250,12 @@ class TestRefresh:
 
         assert response.status_code == 200
         data = response.json()
-        assert "access_token" in data
-        assert "refresh_token" in data
+        assert "access_token" not in data
+        assert "refresh_token" not in data
+        assert "csrf_token" in data
         assert data["token_type"] == "bearer"
         # New refresh token must differ from the consumed one (rotation)
-        assert data["refresh_token"] != refresh_token_str
+        assert response.cookies["refresh_token"] != refresh_token_str
 
     async def test_refresh_rotates_old_token_deleted_from_db(
         self, client: AsyncClient, db_session: AsyncSession, refresh_token_str: str
@@ -303,20 +307,17 @@ class TestRefresh:
         )
         assert response.status_code == 401
 
-    async def test_refresh_new_access_token_grants_access_to_me(
+    async def test_refresh_sets_access_cookie_that_grants_access_to_me(
         self, client: AsyncClient, refresh_token_str: str
     ):
-        """The new access token from a refresh should work on protected endpoints."""
+        """A refresh response should set an access cookie that works on /me."""
         refresh_response = await client.post(
             "/api/auth/refresh",
             json={"refresh_token": refresh_token_str},
         )
-        new_access_token = refresh_response.json()["access_token"]
+        assert refresh_response.status_code == 200
 
-        me_response = await client.get(
-            "/api/auth/me",
-            headers={"Authorization": f"Bearer {new_access_token}"},
-        )
+        me_response = await client.get("/api/auth/me")
         assert me_response.status_code == 200
 
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -210,7 +210,7 @@ All tables live in the `quaero` schema for isolation on shared PostgreSQL.
 - **Auth:** None
 - **Rate Limit:** 5/minute per IP
 - **Request Body:** `{ "username": "string", "password": "string" }`
-- **Success (200):** `{ "access_token": "jwt...", "refresh_token": "hex64...", "token_type": "bearer" }`
+- **Success (200):** `{ "csrf_token": "opaque...", "token_type": "bearer" }`
 - **Errors:**
   - 401: Invalid username or password
 
@@ -218,7 +218,7 @@ All tables live in the `quaero` schema for isolation on shared PostgreSQL.
 - **Auth:** None (refresh token is the credential)
 - **Rate Limit:** 10/minute per IP
 - **Request Body:** `{ "refresh_token": "string" }`
-- **Success (200):** `{ "access_token": "jwt...", "refresh_token": "new-hex64...", "token_type": "bearer" }`
+- **Success (200):** `{ "csrf_token": "opaque...", "token_type": "bearer" }`
 - **Notes:** Rotates the token — old token is deleted, new one issued. Reusing a consumed token returns 401.
 - **Errors:**
   - 401: Invalid or expired refresh token

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -200,6 +200,7 @@ const documents = await api.getDocuments();
 ### Auth Token
 
 Stored in httpOnly cookies set by the backend on login/refresh. JS cannot read the `access_token` or `refresh_token` cookies directly.
+Login/refresh JSON bodies must not include `access_token` or `refresh_token`; they return only browser-safe fields (`csrf_token`, `token_type`).
 
 Because frontend and backend are on different domains, the frontend reads `csrf_token` from login/refresh JSON responses and stores it in `localStorage`. `getCsrfToken()` in `lib/api.ts` reads this value and echoes it as `X-CSRF-Token` on mutating requests (double-submit CSRF pattern). `isLoggedIn()` checks for the presence of this `localStorage` value as a fast client-side session indicator.
 

--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -18,6 +18,7 @@ Post-implementation verification checklist. Run through after every feature befo
 - [ ] CORS restricted to specific frontend origin (no wildcard in production)
 - [ ] Passwords hashed with Argon2 (never stored plaintext)
 - [ ] JWT tokens validated on every protected request
+- [ ] Login/refresh response bodies do not expose `access_token` or `refresh_token`
 - [ ] No SQL string interpolation or f-strings in queries
 - [ ] Error messages don't expose internals (stack traces, DB errors, file paths)
 - [ ] Background job endpoints are non-blocking (no long-running work in request handlers)

--- a/docs/adr/001-cross-domain-csrf-split-token.md
+++ b/docs/adr/001-cross-domain-csrf-split-token.md
@@ -93,4 +93,4 @@ Additionally, to break the login deadlock:
 - The `csrf_token` cookie is still set on the response for potential future same-origin clients or debugging visibility.
 - `localStorage` is readable by JS: XSS can read the CSRF token and make authenticated requests. However, XSS cannot steal the httpOnly `access_token` or `refresh_token` — the session credentials are still protected. The CSRF token alone is insufficient to impersonate a user without the accompanying httpOnly cookies.
 - If `localStorage` is cleared while cookies persist, `isLoggedIn()` returns `false`, redirecting the user to login, which now succeeds without CSRF (exemption from point 9).
-- The `access_token` and `refresh_token` fields remain in the response body for backward compatibility with Swagger UI and any non-cookie clients.
+- `access_token` and `refresh_token` were initially kept in response bodies for compatibility, but this was later removed by ADR-006 for token confidentiality hardening.

--- a/docs/adr/006-auth-response-token-removal.md
+++ b/docs/adr/006-auth-response-token-removal.md
@@ -1,0 +1,77 @@
+# ADR-006: Remove Auth Tokens from Login/Refresh Response Bodies
+
+**Date:** 2026-02-28
+**Status:** Applied
+**Branch:** task-20-remove-auth-token-response-body
+
+---
+
+## Context
+
+### Background
+The application uses cookie-based authentication for browser clients:
+`access_token` and `refresh_token` are stored in httpOnly cookies, and
+`csrf_token` is returned in JSON so cross-domain frontend code can persist it
+in `localStorage` for the `X-CSRF-Token` header.
+
+### Problem
+`POST /api/auth/login` and `POST /api/auth/refresh` still serialized
+`access_token` and `refresh_token` in JSON response bodies. This duplicated
+sensitive credentials into JavaScript-readable responses even though the
+runtime auth path already relies on httpOnly cookies.
+
+### Root Cause (if a bug or production incident)
+A backward-compatibility decision kept token fields in response bodies after
+cookie-auth migration. That compatibility path became a security hardening gap
+once browser clients no longer needed those fields.
+
+---
+
+## Options Considered
+
+### Option A: Remove token fields with no legacy compatibility path
+Remove `access_token` and `refresh_token` from login/refresh JSON bodies for
+all clients, keep only browser-safe fields (`csrf_token`, `token_type`), and
+continue cookie-based auth as the canonical flow.
+
+**Accepted.** This closes the confidentiality gap with the smallest code
+surface and no additional security exceptions.
+
+### Option B: Feature-flag token-bearing responses
+Keep old response fields behind a temporary feature flag.
+
+**Rejected.** Adds configuration complexity and extends the period where token
+leakage through JSON responses remains possible.
+
+### Option C: Separate legacy endpoint that returns tokens
+Keep current endpoints hardened and add explicit legacy endpoints for token
+response bodies.
+
+**Rejected.** Introduces parallel auth contracts and permanently increases
+maintenance and attack surface for a non-goal in this task.
+
+---
+
+## Decision
+
+1. `POST /api/auth/login` now returns only `{ csrf_token, token_type }`.
+2. `POST /api/auth/refresh` now returns only `{ csrf_token, token_type }`.
+3. Auth cookies are still set/rotated identically (`access_token`,
+   `refresh_token`, `csrf_token` cookies).
+4. Frontend auth types and callers now expect only CSRF/token-type payload
+   fields.
+5. Auth regression tests enforce that token fields are absent from login/refresh
+   JSON responses while verifying cookie auth flow remains intact.
+
+---
+
+## Consequences
+
+- Browser clients keep working without behavior changes because cookie transport
+  remains the auth credential path.
+- JSON response bodies no longer expose `access_token` and `refresh_token` to
+  JavaScript.
+- Legacy clients that depended on token fields in login/refresh response bodies
+  must migrate to cookie-auth flow or another explicit auth contract.
+- API documentation and tests must keep this response-shape contract enforced to
+  prevent accidental regressions.

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -9,7 +9,7 @@ import Link from "next/link";
 import { api, saveTokens } from "@/lib/api";
 
 /**
- * Renders centered login form. Submits to api.login, saves access_token to
+ * Renders centered login form. Submits to api.login, saves csrf_token to
  * localStorage, then redirects to /dashboard. Link to register for new users.
  */
 export default function LoginPage() {

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -11,7 +11,7 @@ import { api, saveTokens } from "@/lib/api";
 
 /**
  * Renders centered registration form. On submit: api.register, then api.login
- * to get token and redirect. Link to login for existing users.
+ * to get csrf token and redirect. Link to login for existing users.
  */
 export default function RegisterPage() {
   const [username, setUsername] = useState("");

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -202,9 +202,8 @@ export const api = {
   },
 
   /**
-   * Log in; returns the token body for backward compatibility.
-   * The backend also sets httpOnly auth cookies — those are what
-   * subsequent requests rely on. saveTokens() is now a no-op.
+   * Log in; backend sets httpOnly auth cookies and returns csrf_token.
+   * subsequent requests rely on cookies; csrf_token is persisted locally.
    */
   login: async (credentials: LoginCredentials): Promise<AuthResponse> => {
     return apiRequest("/api/auth/login", {

--- a/frontend/lib/api.types.ts
+++ b/frontend/lib/api.types.ts
@@ -28,8 +28,6 @@ export interface RegisterData {
 }
 
 export interface AuthResponse {
-  access_token: string;
-  refresh_token: string;
   csrf_token: string; // returned in body for cross-domain clients (see ADR-001)
   token_type: string;
 }


### PR DESCRIPTION
## Summary
Remove `access_token` and `refresh_token` from login/refresh JSON response bodies while preserving cookie-auth behavior.

## Linked Issue
- Closes #20

## Scope
**In scope:**
- Backend login/refresh response contract updated to return only `csrf_token` + `token_type`
- Frontend auth response typing/comments aligned to new contract
- Auth regression tests updated for response-shape hardening and cookie-auth flow continuity
- Docs updated (architecture, patterns, checklist, test plan)
- ADR-006 added for the compatibility/security decision

**Out of scope:**
- Auth redesign
- New non-browser auth strategy
- Other P1 hardening tasks from Spec #19

## Acceptance Criteria Check
- [x] Acceptance criteria from Task issue are fully met

## Verification
```bash
make backend-verify
make frontend-verify  # fails in this environment only at build due blocked Google Fonts fetch
cd backend && .venv/bin/pytest -v tests/test_auth.py
cd frontend && npx tsc --noEmit
cd frontend && npm run lint
```

## Docs and Decisions
- [x] Docs updated as needed
- [x] ADR created/linked if decision has lasting architecture/security/perf impact

## Risks / Rollback
- Risk level: Medium (breaking contract for legacy clients that parsed auth tokens from login/refresh JSON)
- Rollback plan: Revert commit `03c2ec1` to restore previous response body fields and tests.

## Follow-up
- If non-cookie clients must be supported, define and implement a dedicated legacy/non-browser auth contract in a separate task instead of reintroducing token-bearing browser responses.
