### PR TITLE
Task #21: Make refresh rotation atomic under concurrency

### DIFF
--- a/TESTPLAN.md
+++ b/TESTPLAN.md
@@ -33,12 +33,15 @@ Test case definitions for Quaero. Tests are defined here before implementation. 
 - Username with leading/trailing whitespace [?] (currently no trim)
 - Very long password (128+ chars) is handled
 - Email with valid but unusual format (plus addressing, etc.)
+- Concurrent POST `/api/auth/refresh` requests using the same refresh token allow at most one success
+- Reusing a consumed refresh token is rejected with 401
 
 ### Security Cases
 
 - Rate limit: register limited to 3/hour per IP
 - Rate limit: login limited to 5/minute per IP
 - Token cannot be decoded with wrong secret key
+- Refresh rotation keeps a single route-level transaction boundary (no helper-side commits)
 
 ---
 

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,8 +1,8 @@
 from app.api.dependencies import get_current_user
 from app.core.security import (
+    consume_refresh_token,
     create_access_token,
     create_refresh_token,
-    validate_refresh_token,
     verify_password,
 )
 from app.crud.user import create_user, get_user_by_email, get_user_by_username
@@ -117,17 +117,15 @@ async def refresh(
             detail="Invalid or expired refresh token",
         )
 
-    row = await validate_refresh_token(refresh_token_value, db)
-    if row is None:
+    # Single-statement consume gate: only one request can consume a token.
+    user_id = await consume_refresh_token(refresh_token_value, db)
+    if user_id is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired refresh token",
         )
 
-    user_id: int = row.user_id  # type: ignore
-
-    # Rotation: delete consumed token and stage new one in the same transaction
-    await db.execute(delete(RefreshToken).where(RefreshToken.id == row.id))
+    # Rotation: consumed old token + staged new token in one transaction.
     new_refresh_token = await create_refresh_token(user_id, db)
     await db.commit()  # single commit — both operations succeed or both roll back
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Optional
 
 from jose import JWTError, jwt
 from passlib.context import CryptContext
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
@@ -91,6 +91,26 @@ async def create_refresh_token(user_id: int, db: AsyncSession) -> str:
     return raw_token
 
 
+async def consume_refresh_token(token: str, db: AsyncSession) -> Optional[int]:
+    """
+    Atomically consume an unexpired refresh token.
+
+    Returns the token's user_id if the token existed and was valid; otherwise
+    returns None. Does NOT commit — caller owns transaction boundaries.
+    """
+    from app.models.refresh_token import RefreshToken
+
+    stmt = (
+        delete(RefreshToken)
+        .where(
+            RefreshToken.token == token,
+            RefreshToken.expires_at >= func.now(),
+        )
+        .returning(RefreshToken.user_id)
+    )
+    return await db.scalar(stmt)
+
+
 async def validate_refresh_token(
     token: str, db: AsyncSession
 ) -> Optional["RefreshToken"]:
@@ -98,7 +118,7 @@ async def validate_refresh_token(
     Look up a refresh token in the DB.
 
     Returns the RefreshToken row if found and not expired, otherwise None.
-    Does NOT delete the row — callers handle deletion for rotation/expiry.
+    Expired rows are staged for deletion. Caller owns commit/rollback.
     """
     from app.models.refresh_token import RefreshToken
 
@@ -117,6 +137,5 @@ async def validate_refresh_token(
     if expires_aware < datetime.now(timezone.utc):
         # Expired — clean up and signal failure
         await db.execute(delete(RefreshToken).where(RefreshToken.id == row.id))
-        await db.commit()
         return None
     return row

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -4,17 +4,21 @@ Tests for authentication endpoints: register, login, me, refresh, logout.
 Covers TESTPLAN.md "Feature: Authentication".
 """
 
+import asyncio
+import uuid
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from httpx import AsyncClient
-from sqlalchemy import select
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.security import create_refresh_token
+from app.core.security import create_refresh_token, get_password_hash, validate_refresh_token
+from app.database import get_db
+from app.main import app
 from app.models.refresh_token import RefreshToken
 from app.models.user import User
-from tests.conftest import TEST_PASSWORD
+from tests.conftest import TEST_PASSWORD, TestAsyncSession
 
 
 # ---------------------------------------------------------------------------
@@ -319,6 +323,136 @@ class TestRefresh:
 
         me_response = await client.get("/api/auth/me")
         assert me_response.status_code == 200
+
+    async def test_refresh_concurrent_requests_only_one_succeeds(self):
+        """Two concurrent refreshes for one token must not both succeed."""
+        user_id: int | None = None
+        refresh_token: str | None = None
+
+        try:
+            async with TestAsyncSession() as seed_session:
+                suffix = uuid.uuid4().hex[:8]
+                user = User(
+                    username=f"race_user_{suffix}",
+                    email=f"race_{suffix}@example.com",
+                    hashed_password=get_password_hash(TEST_PASSWORD),
+                )
+                seed_session.add(user)
+                await seed_session.flush()
+                user_id = user.id
+                refresh_token = await create_refresh_token(user.id, seed_session)
+                await seed_session.commit()
+
+            assert user_id is not None
+            assert refresh_token is not None
+
+            async def _override_get_db():
+                async with TestAsyncSession() as session:
+                    yield session
+
+            app.dependency_overrides[get_db] = _override_get_db
+            app.state.limiter.enabled = False
+
+            transport = ASGITransport(app=app)
+            async with (
+                AsyncClient(transport=transport, base_url="http://test") as client_a,
+                AsyncClient(transport=transport, base_url="http://test") as client_b,
+            ):
+                response_a, response_b = await asyncio.gather(
+                    client_a.post(
+                        "/api/auth/refresh",
+                        json={"refresh_token": refresh_token},
+                    ),
+                    client_b.post(
+                        "/api/auth/refresh",
+                        json={"refresh_token": refresh_token},
+                    ),
+                )
+
+            assert sorted([response_a.status_code, response_b.status_code]) == [200, 401]
+
+            async with TestAsyncSession() as verify_session:
+                rows = (
+                    await verify_session.scalars(
+                        select(RefreshToken).where(RefreshToken.user_id == user_id)
+                    )
+                ).all()
+                assert len(rows) == 1
+                assert rows[0].token != refresh_token
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.state.limiter.enabled = True
+
+            if user_id is not None:
+                async with TestAsyncSession() as cleanup_session:
+                    await cleanup_session.execute(
+                        delete(RefreshToken).where(RefreshToken.user_id == user_id)
+                    )
+                    await cleanup_session.execute(delete(User).where(User.id == user_id))
+                    await cleanup_session.commit()
+
+    async def test_refresh_rollback_preserves_old_token_on_rotation_failure(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """If rotation fails before commit, old token must remain valid in DB."""
+        refresh_token = await create_refresh_token(test_user.id, db_session)
+        await db_session.commit()
+
+        async def _raise_during_rotation(_user_id: int, _db: AsyncSession) -> str:
+            raise RuntimeError("forced refresh rotation failure")
+
+        monkeypatch.setattr("app.api.auth.create_refresh_token", _raise_during_rotation)
+
+        with pytest.raises(RuntimeError):
+            await client.post(
+                "/api/auth/refresh",
+                json={"refresh_token": refresh_token},
+            )
+
+        # Roll back staged changes in this test transaction and verify old token remains.
+        await db_session.rollback()
+        row = await db_session.scalar(
+            select(RefreshToken).where(RefreshToken.token == refresh_token)
+        )
+        assert row is not None
+
+
+class TestRefreshTokenHelperContract:
+    """Contract tests for refresh-token helper transaction ownership."""
+
+    async def test_validate_refresh_token_does_not_commit(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Expired-token cleanup is staged only; helper must not commit."""
+        expired_token = "d" * 64
+        db_session.add(
+            RefreshToken(
+                user_id=test_user.id,
+                token=expired_token,
+                expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+            )
+        )
+        await db_session.flush()
+
+        async def _unexpected_commit() -> None:
+            raise AssertionError("validate_refresh_token must not call commit()")
+
+        monkeypatch.setattr(db_session, "commit", _unexpected_commit)
+
+        row = await validate_refresh_token(expired_token, db_session)
+        assert row is None
+
+        deleted_row = await db_session.scalar(
+            select(RefreshToken).where(RefreshToken.token == expired_token)
+        )
+        assert deleted_row is None
 
 
 class TestLogout:

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -137,6 +137,14 @@ raise HTTPException(status_code=404, detail="Document not found")
 raise HTTPException(status_code=400, detail="Only PDF files are allowed")
 ```
 
+### Refresh Token Rotation
+
+The refresh endpoint consumes tokens with a single SQL statement (`DELETE ... RETURNING`) and commits exactly once after staging the replacement token.
+
+- Prevents read-then-delete races under concurrent refresh attempts.
+- Keeps transaction ownership at the route level.
+- Security helpers (`create_refresh_token`, `validate_refresh_token`, consume helpers) must not call `commit()`.
+
 ### Document Ownership
 
 Every query for user-specific data filters by `current_user.id`. Never trust the client.


### PR DESCRIPTION
## Summary
- switch `/api/auth/refresh` to an atomic consume gate using `DELETE ... RETURNING`
- keep route-level transaction ownership (single commit after consume + mint)
- remove helper-side commit from `validate_refresh_token` to preserve transaction boundaries
- add auth tests for concurrent refresh usage, consumed-token reuse behavior, and rollback/transaction-boundary guarantees
- document refresh rotation contract updates in `docs/PATTERNS.md` and add test cases in `TESTPLAN.md`

## Decision Locks
- Atomic consume strategy: **`DELETE ... RETURNING`** (chosen over `SELECT ... FOR UPDATE` for single-statement consume semantics and lower lock orchestration complexity)
- `validate_refresh_token` contract: **lookup/delete-only, no helper-side commit**

## Verification
- `make backend-verify`
- `cd backend && .venv/bin/pytest -v tests/test_auth.py`

## Risks / Notes
- Expired refresh tokens are now rejected without eager delete in the refresh consume path; startup cleanup still removes expired rows.
- Concurrency guarantee relies on PostgreSQL statement atomicity for the delete-returning consume gate.

Closes #21
Parent Spec: #19
