### PR TITLE
Task #24: Make rate-limit identity proxy-aware and spoof-safe

### DIFF
--- a/TESTPLAN.md
+++ b/TESTPLAN.md
@@ -40,6 +40,10 @@ Test case definitions for Quaero. Tests are defined here before implementation. 
 
 - Rate limit: register limited to 3/hour per IP
 - Rate limit: login limited to 5/minute per IP
+- Rate-limit IP identity uses `X-Forwarded-For` only when the direct peer is in `trusted_proxy_ips`
+- Untrusted peers cannot influence rate-limit identity via forwarded-header spoofing
+- Spoofing a whitelisted IP in forwarded headers does not bypass limits
+- Authenticated rate-limit keys still resolve to `user:<id>` (Bearer and cookie fallback)
 - Token cannot be decoded with wrong secret key
 - Refresh rotation keeps a single route-level transaction boundary (no helper-side commits)
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -39,6 +39,7 @@ class Settings(BaseSettings):
     frontend_url: str = "http://localhost:3000"
 
     whitelisted_ips: list[str] = []
+    trusted_proxy_ips: list[str] = []
 
     redis_url: str = "redis://localhost:6379/0"
     arq_queue_name: str = "quaero:queue"

--- a/backend/app/utils/rate_limit.py
+++ b/backend/app/utils/rate_limit.py
@@ -1,3 +1,4 @@
+import ipaddress
 import uuid
 
 from app.config import settings
@@ -15,9 +16,89 @@ def _is_ip_whitelisted(client_ip: str) -> bool:
     return client_ip in whitelist
 
 
+def _parse_ip(ip: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    """Return a parsed IP address, or None for invalid values."""
+    try:
+        return ipaddress.ip_address(ip.strip())
+    except ValueError:
+        return None
+
+
+def _is_trusted_proxy(client_ip: str) -> bool:
+    """Check whether the direct peer IP belongs to a trusted proxy range."""
+    client_ip_obj = _parse_ip(client_ip)
+    if client_ip_obj is None:
+        return False
+
+    for proxy_ip in settings.trusted_proxy_ips:
+        candidate = proxy_ip.strip()
+        if not candidate:
+            continue
+        try:
+            network = ipaddress.ip_network(candidate, strict=False)
+        except ValueError:
+            logger.warning("Ignoring invalid trusted proxy entry: %s", proxy_ip)
+            continue
+        if client_ip_obj in network:
+            return True
+    return False
+
+
+def _resolve_forwarded_for_client_ip(
+    x_forwarded_for: str, peer_ip: str
+) -> str | None:
+    """
+    Resolve the client IP from a trusted X-Forwarded-For chain.
+
+    The chain is interpreted right-to-left and trusted hops are stripped until
+    the first untrusted IP is found. This avoids trusting client-injected
+    left-most values.
+    """
+    forwarded_ips = [entry.strip() for entry in x_forwarded_for.split(",") if entry.strip()]
+    if not forwarded_ips:
+        return None
+
+    normalized_chain: list[str] = []
+    for ip in forwarded_ips:
+        parsed_ip = _parse_ip(ip)
+        if parsed_ip is None:
+            return None
+        normalized_chain.append(str(parsed_ip))
+
+    normalized_chain.append(peer_ip)
+
+    for hop_ip in reversed(normalized_chain):
+        if _is_trusted_proxy(hop_ip):
+            continue
+        return hop_ip
+
+    return None
+
+
 def _client_ip(request: Request) -> str:
-    """Get client IP from request."""
-    return request.client.host if request.client else "127.0.0.1"
+    """
+    Derive client IP safely.
+
+    Forwarded headers are only trusted when the direct peer is configured as a
+    trusted proxy. Otherwise, spoofed headers are ignored.
+    """
+    peer_ip = request.client.host if request.client else "127.0.0.1"
+    if not _is_trusted_proxy(peer_ip):
+        return peer_ip
+
+    x_forwarded_for = request.headers.get("X-Forwarded-For")
+    if x_forwarded_for:
+        forwarded_client_ip = _resolve_forwarded_for_client_ip(x_forwarded_for, peer_ip)
+        if forwarded_client_ip:
+            return forwarded_client_ip
+
+    x_real_ip = request.headers.get("X-Real-IP")
+    if x_real_ip:
+        parsed_ip = _parse_ip(x_real_ip)
+        if parsed_ip:
+            return str(parsed_ip)
+
+    return peer_ip
 
 
 def get_ip_key(request: Request) -> str:

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,0 +1,95 @@
+"""Rate-limit identity tests for trusted and non-trusted proxy paths."""
+
+import pytest
+from starlette.requests import Request
+
+from app.config import settings
+from app.core.security import create_access_token
+from app.utils.rate_limit import get_ip_key, get_user_or_ip_key
+
+
+def _build_request(
+    client_ip: str,
+    *,
+    headers: dict[str, str] | None = None,
+    cookies: dict[str, str] | None = None,
+) -> Request:
+    """Create a minimal Request object for rate-limit key tests."""
+    raw_headers: list[tuple[bytes, bytes]] = []
+    for key, value in (headers or {}).items():
+        raw_headers.append((key.lower().encode("latin-1"), value.encode("latin-1")))
+
+    if cookies:
+        cookie_header = "; ".join(f"{key}={value}" for key, value in cookies.items())
+        raw_headers.append((b"cookie", cookie_header.encode("latin-1")))
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": raw_headers,
+        "client": (client_ip, 12345),
+        "server": ("testserver", 80),
+    }
+    return Request(scope)
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limit_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset rate-limit config knobs between tests."""
+    monkeypatch.setattr(settings, "trusted_proxy_ips", [])
+    monkeypatch.setattr(settings, "whitelisted_ips", [])
+
+
+def test_get_ip_key_ignores_forwarded_headers_from_untrusted_peer() -> None:
+    request = _build_request(
+        "198.51.100.25",
+        headers={"X-Forwarded-For": "203.0.113.77"},
+    )
+
+    assert get_ip_key(request) == "198.51.100.25"
+
+
+def test_get_ip_key_uses_trusted_proxy_chain_and_ignores_left_spoof() -> None:
+    settings.trusted_proxy_ips = ["10.0.0.0/8"]
+    request = _build_request(
+        "10.2.3.4",
+        headers={"X-Forwarded-For": "1.1.1.1, 198.51.100.44, 10.9.9.9"},
+    )
+
+    assert get_ip_key(request) == "198.51.100.44"
+
+
+def test_get_ip_key_does_not_whitelist_bypass_with_untrusted_spoof() -> None:
+    settings.whitelisted_ips = ["203.0.113.9"]
+    request = _build_request(
+        "198.51.100.25",
+        headers={"X-Forwarded-For": "203.0.113.9"},
+    )
+
+    assert get_ip_key(request) == "198.51.100.25"
+
+
+def test_get_user_or_ip_key_keeps_user_key_for_bearer_token_behind_proxy() -> None:
+    settings.trusted_proxy_ips = ["10.0.0.0/8"]
+    token = create_access_token(data={"sub": "42"})
+    request = _build_request(
+        "10.2.3.4",
+        headers={
+            "X-Forwarded-For": "198.51.100.51",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+
+    assert get_user_or_ip_key(request) == "user:42"
+
+
+def test_get_user_or_ip_key_keeps_cookie_fallback_for_authenticated_user() -> None:
+    token = create_access_token(data={"sub": "99"})
+    request = _build_request("198.51.100.25", cookies={"access_token": token})
+
+    assert get_user_or_ip_key(request) == "user:99"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -197,6 +197,10 @@ All tables live in the `quaero` schema for isolation on shared PostgreSQL.
 
 ### Authentication
 
+Rate-limit IP identity is proxy-aware: the backend trusts `X-Forwarded-For`
+only when the direct peer IP is in `trusted_proxy_ips`; otherwise it falls
+back to socket peer IP to prevent header spoofing.
+
 #### POST /api/auth/register
 - **Auth:** None
 - **Rate Limit:** 3/hour per IP

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -137,6 +137,11 @@ Use `@limiter.limit()` decorator with appropriate key function:
 def login(request: Request, ...):
 ```
 
+Proxy-aware identity rule:
+- Trust `X-Forwarded-For` only when the direct peer IP is in `settings.trusted_proxy_ips` (IP/CIDR list).
+- Resolve client IP by stripping trusted hops right-to-left in the forwarded chain.
+- Ignore forwarded headers from untrusted peers.
+
 ### Error Responses
 
 Always use `HTTPException` with `detail` string. Never return raw error objects.

--- a/docs/adr/007-trusted-proxy-rate-limit-identity.md
+++ b/docs/adr/007-trusted-proxy-rate-limit-identity.md
@@ -1,0 +1,69 @@
+# ADR-007: Trusted Proxy Boundary for Rate-Limit Identity
+
+**Date:** 2026-03-01
+**Status:** Applied
+**Branch:** task-24-proxy-aware-rate-limit-identity
+
+---
+
+## Context
+
+### Background
+Rate-limit keys for public endpoints are IP-based. In production, traffic may
+arrive through one or more reverse proxies that set `X-Forwarded-For`.
+
+### Problem
+Using only `request.client.host` behind proxies can collapse many users into a
+single proxy IP. Blindly trusting forwarded headers can allow spoofing and
+rate-limit bypass.
+
+### Root Cause (if a bug or production incident)
+Rate-limit identity derivation had no explicit trusted-proxy boundary and did
+not define how to handle forwarded-header chains safely.
+
+---
+
+## Options Considered
+
+### Option A: App-level trusted proxy parsing for rate-limit identity
+Parse `X-Forwarded-For` only when the direct peer is in an explicit
+`trusted_proxy_ips` list (IP/CIDR). Strip trusted hops right-to-left and use
+the first untrusted IP as the client identity.
+
+**Accepted.** Keeps trust boundaries explicit in app config, avoids blind
+header trust, and preserves correct client identity through multi-hop proxies.
+
+### Option B: Depend on Uvicorn proxy-header rewriting for all identity
+Trust `request.client.host` after Uvicorn proxy handling and rely on runtime
+`--forwarded-allow-ips` for security.
+
+**Rejected.** Correctness and spoof-safety would depend entirely on runtime
+flags; misconfiguration can silently widen trust.
+
+---
+
+## Decision
+
+1. Added `trusted_proxy_ips` configuration (IP/CIDR list) for backend trust
+   boundaries.
+2. Updated rate-limit IP derivation to trust forwarded headers only when the
+   direct peer is trusted.
+3. Implemented right-to-left trusted-hop stripping for `X-Forwarded-For`.
+4. Preserved existing auth-first behavior for `get_user_or_ip_key` (user ID key
+   when token is valid, IP fallback otherwise).
+5. Added regression tests for non-proxied behavior, trusted-proxy behavior, and
+   spoofing resistance.
+
+---
+
+## Consequences
+
+- Deployments behind proxies must set `trusted_proxy_ips` correctly, otherwise
+  limits fall back to proxy peer IPs.
+- Forwarded-header spoofing from untrusted direct peers does not alter
+  rate-limit identity.
+- Behavior remains backward-compatible for authenticated endpoints that already
+  key on `user:<id>`.
+- Runtime proxy settings should avoid broad trust (for example wildcard
+  forwarded-allow lists), because this ADR assumes direct-peer trust is
+  deliberate and explicit.


### PR DESCRIPTION
## Summary
- add explicit `trusted_proxy_ips` backend setting for proxy trust boundaries
- derive rate-limit client IP from `X-Forwarded-For` only when direct peer is trusted, stripping trusted hops right-to-left
- keep authenticated user-key behavior intact and add regression tests for proxied/non-proxied/spoofing paths
- document the policy in TESTPLAN, PATTERNS, ARCHITECTURE, and ADR-007

## Trusted-proxy assumptions
- direct peer IP is authoritative for trust decisions and must be a known reverse proxy (`trusted_proxy_ips`)
- forwarded headers from untrusted direct peers are ignored
- if proxy chains are present, trusted hops are removed from the right side of `X-Forwarded-For` and the first untrusted IP is used as client identity
- deployments should avoid broad runtime proxy trust (for example wildcard forwarded-allow lists)

## Verification
- `make backend-verify`
- `cd backend && .venv/bin/pytest -v tests/test_auth.py tests/test_documents.py`
- `cd backend && .venv/bin/pytest -v tests/test_rate_limit.py`

Closes #24
