### PR TITLE
Fix deploy: provision backend env from GitHub secret

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -76,10 +76,28 @@ jobs:
           echo "${{ secrets.GCP_VM_SSH_KEY }}" > vm_key.pem
           chmod 600 vm_key.pem
 
-      - name: Ensure deploy dir exists on VM
+      - name: Render backend env file from GitHub secret
+        run: |
+          if [ -z "${{ secrets.BACKEND_ENV_B64 }}" ]; then
+            echo "Missing required GitHub secret: BACKEND_ENV_B64"
+            exit 1
+          fi
+          echo "${{ secrets.BACKEND_ENV_B64 }}" | base64 --decode > backend.env
+          chmod 600 backend.env
+
+      - name: Ensure deploy/env dirs exist on VM
         run: |
           ssh -i vm_key.pem -o IdentitiesOnly=yes -o StrictHostKeyChecking=no "${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }}" \
-            "mkdir -p /opt/quaero/deploy"
+            "mkdir -p /opt/quaero/deploy /opt/quaero/env"
+
+      - name: Upload backend env file to VM
+        run: |
+          scp -i vm_key.pem -o IdentitiesOnly=yes -o StrictHostKeyChecking=no \
+            ./backend.env \
+            "${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }}:/opt/quaero/env/backend.env"
+
+          ssh -i vm_key.pem -o IdentitiesOnly=yes -o StrictHostKeyChecking=no "${{ secrets.GCP_VM_USER }}@${{ secrets.GCP_VM_HOST }}" \
+            "chmod 600 /opt/quaero/env/backend.env"
 
       - name: Upload deploy script to VM
         run: |
@@ -98,4 +116,4 @@ jobs:
 
       - name: Cleanup local SSH key
         if: always()
-        run: rm -f vm_key.pem
+        run: rm -f vm_key.pem backend.env

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,7 +33,7 @@ Quaero is a document intelligence platform that allows users to upload PDF docum
 
 - **Terraform ownership (non-DB):** VM instance, static IP, firewall rules, VM service account/IAM, and GCS document bucket are managed from `infra/terraform` via import-first workflow.
 - **Infra hardening defaults:** SSH ingress requires explicit CIDRs, world-open SSH needs explicit temporary opt-in, Shielded VM secure boot defaults on, and VM SA defaults to GCS object-only access scope/role.
-- **Bootstrap model:** VM startup script installs Docker, NGINX, Certbot, and creates `/opt/quaero` deploy/env directories with an env stub.
+- **Bootstrap model:** VM startup script installs Docker, NGINX, Certbot, and creates `/opt/quaero` deploy/env directories. Production `backend.env` is pushed by deploy workflow from GitHub secret `BACKEND_ENV_B64`.
 - **CI trigger policy:** `Backend CI` runs on every PR and direct push to non-`main` branches.
 - **Deploy trigger policy:** `Deploy Backend` runs on `main` pushes and manual `workflow_dispatch` from `main`; deploy is blocked unless backend tests pass.
 - **Control-plane guardrail:** `main` branch protection should require status check `Backend CI / backend-verify`.

--- a/docs/GCP_RUNBOOK.md
+++ b/docs/GCP_RUNBOOK.md
@@ -29,7 +29,6 @@ For full VM reprovision/reset steps, use `docs/GCP_VM_REBUILD_TERRAFORM_PLAN.md`
 
 - GCP VM, static IP, firewall
 - DNS (`api.quaero.odysian.dev`)
-- VM production env file
 - GitHub secrets
 - Vercel `NEXT_PUBLIC_API_URL` update
 - Cloud Storage bucket/IAM setup
@@ -47,10 +46,12 @@ Terraform startup bootstrap now handles Docker + NGINX + Certbot + env file stub
 - `GCP_VM_SSH_KEY`
 - `GHCR_USERNAME`
 - `GHCR_TOKEN`
+- `BACKEND_ENV_B64` (base64-encoded contents of production `backend.env`)
 
-## VM env file
+## Backend env source of truth
 
-Path: `/opt/quaero/env/backend.env`
+Canonical source: GitHub secret `BACKEND_ENV_B64`.
+Deploy workflow writes it to VM path `/opt/quaero/env/backend.env` on every deploy.
 
 Required values:
 
@@ -79,6 +80,12 @@ Do **not** write:
 TRUSTED_PROXY_IPS='["172.17.0.1/32"]'
 ```
 
+Set/update secret from your local env file:
+
+```bash
+base64 -w 0 /path/to/backend.env | gh secret set BACKEND_ENV_B64
+```
+
 ---
 
 ## 3. Deployment Flow (Normal)
@@ -91,8 +98,9 @@ TRUSTED_PROXY_IPS='["172.17.0.1/32"]'
    - manual `workflow_dispatch` from `main` only (`Deploy Backend`)
 3. `Deploy Backend` runs `backend-tests` first. If tests fail, deploy stops.
 4. If tests pass, CI builds and pushes image to GHCR.
-5. CI uploads `ops/deploy_backend.sh` to VM.
-6. CI executes deploy script on VM:
+5. CI renders `backend.env` from `BACKEND_ENV_B64` and uploads it to VM.
+6. CI uploads `ops/deploy_backend.sh` to VM.
+7. CI executes deploy script on VM:
    - pulls image
    - runs migrations
    - restarts container

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -13,7 +13,7 @@ VM bootstrap via startup script also configures:
 - Docker engine
 - NGINX reverse proxy (`server_name = api.quaero.odysian.dev`)
 - Certbot TLS issuance/renewal (when enabled)
-- `/opt/quaero/env/backend.env` stub with placeholders
+- `/opt/quaero/env/backend.env` directory/path (file is provisioned by deploy workflow secret)
 - `/opt/quaero/{deploy,env,logs}` directories
 
 ## Prerequisites
@@ -122,11 +122,14 @@ terraform apply -var-file=envs/prod.tfvars
 
 ## After Apply (Required Before First Deploy)
 
-1. SSH to VM and fill real secrets in `/opt/quaero/env/backend.env` (replace placeholders).
-   - For list env vars (for example `TRUSTED_PROXY_IPS`), use JSON array syntax
-     without outer shell quotes since deployment uses Docker `--env-file`.
-   - Example: `TRUSTED_PROXY_IPS=["172.17.0.1/32"]` (correct),
-     `TRUSTED_PROXY_IPS='["172.17.0.1/32"]'` (incorrect).
+1. Set GitHub repo secret `BACKEND_ENV_B64` from your production env file contents.
+   - Generate a base64 payload from your local env file:
+
+```bash
+base64 -w 0 /path/to/backend.env
+```
+
+   - Add it as repository secret `BACKEND_ENV_B64`.
 2. Confirm NGINX/TLS status:
 
 ```bash
@@ -135,7 +138,7 @@ sudo systemctl status nginx --no-pager
 sudo systemctl status certbot.timer --no-pager
 ```
 
-3. Trigger GitHub Actions `Deploy Backend`.
+3. Trigger GitHub Actions `Deploy Backend` (it now uploads `/opt/quaero/env/backend.env` from `BACKEND_ENV_B64` on every deploy).
 
 ## Outputs
 


### PR DESCRIPTION
## Summary
- update `Deploy Backend` workflow to provision `/opt/quaero/env/backend.env` from GitHub secret `BACKEND_ENV_B64` on every deploy
- fail deploy early with a clear error when `BACKEND_ENV_B64` is missing
- keep deploy script unchanged but remove VM-recreate manual env dependency by making env upload part of CI deploy flow
- update infra/runbook/architecture docs to reflect new env source-of-truth and setup steps

## Why
VM recreation can remove `/opt/quaero/env/backend.env`, which previously required manual SSH repair before every deploy. This change makes env restoration deterministic and automated.

## One-time setup
Set repository secret:

```bash
base64 -w 0 /path/to/backend.env | gh secret set BACKEND_ENV_B64
```

## Verification
- workflow YAML parses successfully
- deploy workflow now includes: secret decode -> env upload -> deploy script execution
