### PR TITLE
Bump FastAPI to 0.135.1 for SSE support

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,7 +19,7 @@ dnspython==2.8.0
 docstring_parser==0.17.0
 ecdsa==0.19.1
 email-validator==2.3.0
-fastapi==0.128.0
+fastapi==0.135.1
 google-cloud-storage==2.19.0
 greenlet==3.3.0
 h11==0.16.0


### PR DESCRIPTION
## Summary
- Bumped `fastapi` from `0.128.0` to `0.135.1` in `backend/requirements.txt`.
- Verified SSE imports: `from fastapi.sse import EventSourceResponse, ServerSentEvent`.
- Ran full backend verification after dependency update.

## Parent Spec
- #35

## Decision Brief
Chosen version: `0.135.1` (latest stable `>=0.135.0` with first-class SSE); reviewed upgrade notes and found strict JSON `Content-Type` enforcement + `ORJSONResponse`/`UJSONResponse` deprecations, with no repo regressions observed.

## Verification
- `cd backend && .venv/bin/python -c "from fastapi.sse import EventSourceResponse, ServerSentEvent; print('SSE imports OK')"`
- `make backend-verify` (ruff, mypy, pytest, bandit)

Closes #36
