### PR TITLE
Task #50: Add high-value frontend regression tests

### DIFF
--- a/TESTPLAN.md
+++ b/TESTPLAN.md
@@ -182,6 +182,28 @@ Test case definitions for Quaero. Tests are defined here before implementation. 
 
 ---
 
+## Feature: Frontend Auth and Dashboard Regression
+
+### Happy Path
+
+- `apiRequest()` retries the original request once after a successful refresh (`401 -> /auth/refresh -> retry`)
+- Dashboard loads the document list successfully and renders document rows
+- Dashboard renders the empty-state message when the document list is empty
+- Dashboard upload success path calls upload API and reloads the document list
+- Dashboard process trigger path calls process API and reloads the document list
+- Dashboard delete success path calls delete API and reloads the document list
+- Login form disables submit while request is in flight and re-enables after completion
+- Register form disables submit while request is in flight and re-enables after completion
+
+### Error Cases
+
+- `apiRequest()` refresh failure clears client auth storage and surfaces session-expired behavior
+- Dashboard shows API error text when initial document load fails
+- Login shows API error text after failed submit
+- Register shows API error text after failed submit
+
+---
+
 ## Feature: Document Search
 
 ### Happy Path

--- a/frontend/app/dashboard/__tests__/page.test.tsx
+++ b/frontend/app/dashboard/__tests__/page.test.tsx
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import DashboardPage from "@/app/dashboard/page";
+import { api, ApiError, isLoggedIn, type Document } from "@/lib/api";
+
+const pushMock = vi.fn();
+const routerMock = { push: pushMock };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => routerMock,
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    isLoggedIn: vi.fn(),
+    api: {
+      ...actual.api,
+      getDocuments: vi.fn(),
+      uploadDocument: vi.fn(),
+      processDocument: vi.fn(),
+      getDocumentStatus: vi.fn(),
+      deleteDocument: vi.fn(),
+      logout: vi.fn(),
+    },
+  };
+});
+
+const isLoggedInMock = vi.mocked(isLoggedIn);
+const getDocumentsMock = vi.mocked(api.getDocuments);
+const uploadDocumentMock = vi.mocked(api.uploadDocument);
+const processDocumentMock = vi.mocked(api.processDocument);
+const getDocumentStatusMock = vi.mocked(api.getDocumentStatus);
+const deleteDocumentMock = vi.mocked(api.deleteDocument);
+
+function makeDocument(
+  overrides: Partial<Document> = {}
+): Document {
+  return {
+    id: 101,
+    user_id: 1,
+    filename: "alpha.pdf",
+    file_size: 2048,
+    status: "completed",
+    uploaded_at: "2026-03-01T10:00:00Z",
+    processed_at: "2026-03-01T10:01:00Z",
+    error_message: null,
+    ...overrides,
+  };
+}
+
+describe("DashboardPage regression behavior", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    isLoggedInMock.mockReset();
+    getDocumentsMock.mockReset();
+    uploadDocumentMock.mockReset();
+    processDocumentMock.mockReset();
+    getDocumentStatusMock.mockReset();
+    deleteDocumentMock.mockReset();
+
+    isLoggedInMock.mockReturnValue(true);
+    getDocumentsMock.mockResolvedValue({ documents: [], total: 0 });
+    uploadDocumentMock.mockResolvedValue(makeDocument());
+    processDocumentMock.mockResolvedValue({
+      message: "queued",
+      document_id: 101,
+    });
+    getDocumentStatusMock.mockResolvedValue({
+      id: 101,
+      status: "processing",
+      processed_at: null,
+      error_message: null,
+    });
+    deleteDocumentMock.mockResolvedValue({ message: "deleted" });
+  });
+
+  it("renders loaded documents after successful fetch", async () => {
+    const doc = makeDocument({ filename: "guide.pdf" });
+    getDocumentsMock.mockResolvedValueOnce({ documents: [doc], total: 1 });
+
+    render(<DashboardPage />);
+
+    expect(await screen.findByText("guide.pdf")).toBeInTheDocument();
+    expect(screen.getByText("Select a document")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no documents are returned", async () => {
+    getDocumentsMock.mockResolvedValueOnce({ documents: [], total: 0 });
+
+    render(<DashboardPage />);
+
+    expect(
+      await screen.findByRole("heading", { name: "No documents yet" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders API error text when document load fails", async () => {
+    getDocumentsMock.mockRejectedValueOnce(
+      new ApiError(500, "Failed to load documents from API")
+    );
+
+    render(<DashboardPage />);
+
+    expect(
+      await screen.findByText("Failed to load documents from API")
+    ).toBeInTheDocument();
+  });
+
+  it("uploads a document and reloads the list on success", async () => {
+    const doc = makeDocument();
+    getDocumentsMock
+      .mockResolvedValueOnce({ documents: [doc], total: 1 })
+      .mockResolvedValueOnce({ documents: [doc], total: 1 });
+
+    render(<DashboardPage />);
+
+    await screen.findByText("alpha.pdf");
+    const fileInput = screen.getByLabelText("Upload PDF");
+    const file = new File(["%PDF"], "upload.pdf", { type: "application/pdf" });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(uploadDocumentMock).toHaveBeenCalledWith(file);
+      expect(getDocumentsMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("queues document processing and reloads the list", async () => {
+    const pendingDoc = makeDocument({
+      id: 201,
+      status: "pending",
+      processed_at: null,
+    });
+    const processingDoc = makeDocument({
+      id: 201,
+      status: "processing",
+      processed_at: null,
+    });
+
+    getDocumentsMock
+      .mockResolvedValueOnce({ documents: [pendingDoc], total: 1 })
+      .mockResolvedValueOnce({ documents: [processingDoc], total: 1 });
+
+    render(<DashboardPage />);
+
+    await screen.findByText("alpha.pdf");
+    fireEvent.click(screen.getByRole("button", { name: "Process" }));
+
+    await waitFor(() => {
+      expect(processDocumentMock).toHaveBeenCalledWith(201);
+      expect(getDocumentsMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("deletes a document and reloads the list", async () => {
+    const doc = makeDocument({ id: 301 });
+    getDocumentsMock
+      .mockResolvedValueOnce({ documents: [doc], total: 1 })
+      .mockResolvedValueOnce({ documents: [], total: 0 });
+
+    render(<DashboardPage />);
+
+    await screen.findByText("alpha.pdf");
+    fireEvent.click(screen.getAllByRole("button", { name: "Delete" })[0]);
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(deleteDocumentMock).toHaveBeenCalledWith(301);
+      expect(getDocumentsMock).toHaveBeenCalledTimes(2);
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/app/login/__tests__/page.test.tsx
+++ b/frontend/app/login/__tests__/page.test.tsx
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import LoginPage from "@/app/login/page";
+import { api, saveTokens } from "@/lib/api";
+
+const pushMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    saveTokens: vi.fn(),
+    api: {
+      ...actual.api,
+      login: vi.fn(),
+    },
+  };
+});
+
+const loginMock = vi.mocked(api.login);
+const saveTokensMock = vi.mocked(saveTokens);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("LoginPage form behavior", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    loginMock.mockReset();
+    saveTokensMock.mockReset();
+  });
+
+  it("disables submit while login is in flight and re-enables after success", async () => {
+    const pending = deferred<{ csrf_token: string; token_type: string }>();
+    loginMock.mockReturnValueOnce(pending.promise);
+
+    render(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText("Username"), {
+      target: { value: "alice" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "secret" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+
+    expect(screen.getByRole("button", { name: "Accessing..." })).toBeDisabled();
+
+    pending.resolve({ csrf_token: "csrf-token", token_type: "bearer" });
+
+    await waitFor(() => {
+      expect(saveTokensMock).toHaveBeenCalledWith({
+        csrf_token: "csrf-token",
+        token_type: "bearer",
+      });
+      expect(pushMock).toHaveBeenCalledWith("/dashboard");
+      expect(screen.getByRole("button", { name: "Sign In" })).toBeEnabled();
+    });
+  });
+
+  it("renders API errors and re-enables submit", async () => {
+    loginMock.mockRejectedValueOnce(new Error("Invalid credentials"));
+
+    render(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText("Username"), {
+      target: { value: "alice" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "wrong-pass" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+
+    expect(await screen.findByText("Invalid credentials")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign In" })).toBeEnabled();
+  });
+});

--- a/frontend/app/register/__tests__/page.test.tsx
+++ b/frontend/app/register/__tests__/page.test.tsx
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import RegisterPage from "@/app/register/page";
+import { api, saveTokens } from "@/lib/api";
+
+const pushMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    saveTokens: vi.fn(),
+    api: {
+      ...actual.api,
+      register: vi.fn(),
+      login: vi.fn(),
+    },
+  };
+});
+
+const registerMock = vi.mocked(api.register);
+const loginMock = vi.mocked(api.login);
+const saveTokensMock = vi.mocked(saveTokens);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("RegisterPage form behavior", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    registerMock.mockReset();
+    loginMock.mockReset();
+    saveTokensMock.mockReset();
+  });
+
+  it("disables submit while registering and re-enables after success", async () => {
+    const pendingRegistration = deferred<{
+      id: number;
+      username: string;
+      email: string;
+      created_at: string;
+    }>();
+    registerMock.mockReturnValueOnce(pendingRegistration.promise);
+    loginMock.mockResolvedValueOnce({
+      csrf_token: "csrf-token",
+      token_type: "bearer",
+    });
+
+    render(<RegisterPage />);
+
+    fireEvent.change(screen.getByLabelText("Username"), {
+      target: { value: "alice" },
+    });
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "alice@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "strong-password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Register" }));
+
+    expect(
+      screen.getByRole("button", { name: "Creating account..." })
+    ).toBeDisabled();
+
+    pendingRegistration.resolve({
+      id: 1,
+      username: "alice",
+      email: "alice@example.com",
+      created_at: "2026-03-02T10:00:00Z",
+    });
+
+    await waitFor(() => {
+      expect(registerMock).toHaveBeenCalledWith({
+        username: "alice",
+        email: "alice@example.com",
+        password: "strong-password",
+      });
+      expect(loginMock).toHaveBeenCalledWith({
+        username: "alice",
+        password: "strong-password",
+      });
+      expect(saveTokensMock).toHaveBeenCalledWith({
+        csrf_token: "csrf-token",
+        token_type: "bearer",
+      });
+      expect(pushMock).toHaveBeenCalledWith("/dashboard");
+      expect(screen.getByRole("button", { name: "Register" })).toBeEnabled();
+    });
+  });
+
+  it("renders API errors and re-enables submit", async () => {
+    registerMock.mockRejectedValueOnce(new Error("Username already exists"));
+
+    render(<RegisterPage />);
+
+    fireEvent.change(screen.getByLabelText("Username"), {
+      target: { value: "alice" },
+    });
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "alice@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "strong-password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Register" }));
+
+    expect(await screen.findByText("Username already exists")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Register" })).toBeEnabled();
+  });
+});

--- a/frontend/lib/__tests__/api.auth.test.ts
+++ b/frontend/lib/__tests__/api.auth.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api, ApiError } from "@/lib/api";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("apiRequest auth refresh contract", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    localStorage.clear();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("retries the original request after a successful refresh", async () => {
+    localStorage.setItem("csrf_token", "csrf-old");
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "Unauthorized" }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, { csrf_token: "csrf-new", token_type: "bearer" })
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { documents: [], total: 0 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await api.getDocuments();
+
+    expect(response).toEqual({ documents: [], total: 0 });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:8000/api/documents/");
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": "csrf-old",
+      },
+    });
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("http://localhost:8000/api/auth/refresh");
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": "csrf-old",
+      },
+    });
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("http://localhost:8000/api/documents/");
+    expect(fetchMock.mock.calls[2]?.[1]).toMatchObject({
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": "csrf-new",
+      },
+    });
+  });
+
+  it("clears client auth state and throws session-expired error when refresh fails", async () => {
+    localStorage.setItem("csrf_token", "csrf-old");
+    localStorage.setItem("access_token", "legacy-access");
+    localStorage.setItem("refresh_token", "legacy-refresh");
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "Unauthorized" }))
+      .mockResolvedValueOnce(jsonResponse(401, { detail: "Refresh failed" }));
+    vi.stubGlobal("fetch", fetchMock);
+    const consoleErrorMock = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      await expect(api.getDocuments()).rejects.toMatchObject({
+        status: 401,
+        detail: "Session expired",
+      } satisfies Pick<ApiError, "status" | "detail">);
+    } finally {
+      consoleErrorMock.mockRestore();
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("http://localhost:8000/api/auth/refresh");
+    expect(localStorage.getItem("csrf_token")).toBeNull();
+    expect(localStorage.getItem("access_token")).toBeNull();
+    expect(localStorage.getItem("refresh_token")).toBeNull();
+  });
+});

--- a/plans/high-visibility-features/spec-phase-1-streaming.md
+++ b/plans/high-visibility-features/spec-phase-1-streaming.md
@@ -41,6 +41,7 @@ Add streaming RAG responses and pipeline observability metadata to Quaero. Users
 - [ ] Task: Streaming backend (endpoint + service + P2 fixes)
 - [ ] Task: Streaming frontend (SSE consumer + ChatWindow + pipeline meta UI)
 - [ ] Task: Streaming frontend test coverage (SSE parser + stream lifecycle regression tests)
+- [ ] Task: High-value frontend regression tests (#50) (core auth/dashboard API-contract hardening ahead of Phase 2 UI work)
 
 Split rationale: Backend contract should land and be testable before frontend integration. Frontend test coverage is a dedicated hardening task so later P1 changes can move faster with lower regression risk.
 

--- a/plans/high-visibility-features/task-phase-1-high-value-frontend-regression-tests.md
+++ b/plans/high-visibility-features/task-phase-1-high-value-frontend-regression-tests.md
@@ -1,0 +1,53 @@
+## Summary
+
+Add high-value, low-brittleness frontend regression tests for core user flows that must remain stable through upcoming PDF viewer/frontend rework.
+
+Parent Spec: #38
+Depends on: Task #48 (streaming frontend test coverage)
+
+## What this delivers
+
+1. API client auth/refresh regression tests for core request retry behavior
+2. Dashboard flow tests for document list state and key mutation paths (upload/delete/process trigger behavior via mocked API)
+3. Login/register page behavior tests for submit-state and error rendering
+4. Guardrails to keep tests resilient to UI refactors (behavior-first assertions, no snapshots)
+
+## Acceptance Criteria
+
+- [ ] `apiRequest()` 401 -> refresh -> retry path is covered in frontend tests
+- [ ] `apiRequest()` refresh failure path is covered (session-expired behavior)
+- [ ] Dashboard document-list behavior is covered for load success/error and empty state
+- [ ] Dashboard mutation behavior is covered for upload success path and delete success path
+- [ ] Auth form behavior is covered for submit disable/enable and API-error display
+- [ ] New tests avoid snapshot-heavy assertions and focus on user-visible behavior/state transitions
+- [ ] `make frontend-verify` passes with the expanded suite
+
+## Implementation Notes
+
+- Prioritize tests that protect contracts and lifecycle behavior over fragile styling/layout details.
+- Use React Testing Library interactions and mock API boundaries (`lib/api.ts`) for page/component tests.
+- Keep selectors semantic (`role`, visible text, labels) to reduce churn during UI refactors.
+
+## Verification
+
+```bash
+make frontend-verify
+```
+
+## Files in scope
+
+- `frontend/lib/api.ts` and `frontend/lib/__tests__/`
+- `frontend/app/dashboard/page.tsx` and dashboard component tests
+- `frontend/app/login/page.tsx` tests
+- `frontend/app/register/page.tsx` tests
+- Test setup/util files as needed
+
+## Files explicitly out of scope
+
+- PDF viewer implementation details (Phase 2)
+- Visual styling assertions and snapshot baselines
+- Backend endpoint changes
+
+## Labels
+
+`type:task`, `area:frontend`


### PR DESCRIPTION
## Summary
- add high-value frontend regression tests for auth refresh and dashboard lifecycle behavior
- add login/register form behavior tests for submit-state and API error handling
- update Phase 1 streaming spec child-task list and add the Task #50 plan doc
- update TESTPLAN with frontend auth/dashboard regression coverage

## Testing
- make frontend-verify

Closes #50
