### PR TITLE
Task #52: Harden NGINX SSE proxy behavior in production

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,6 +34,7 @@ Quaero is a document intelligence platform that allows users to upload PDF docum
 - **Terraform ownership (non-DB):** VM instance, static IP, firewall rules, VM service account/IAM, and GCS document bucket are managed from `infra/terraform` via import-first workflow.
 - **Infra hardening defaults:** SSH ingress requires explicit CIDRs, world-open SSH needs explicit temporary opt-in, Shielded VM secure boot defaults on, and VM SA defaults to GCS object-only access scope/role.
 - **Bootstrap model:** VM startup script installs Docker, NGINX, Certbot, and creates `/opt/quaero` deploy/env directories. Production `backend.env` is pushed by deploy workflow from GitHub secret `BACKEND_ENV_B64`.
+- **Streaming proxy hardening:** NGINX includes a dedicated `/api/documents/{id}/query/stream` location with buffering/cache/compression disabled and extended timeouts so SSE tokens flush incrementally to clients.
 - **CI trigger policy:** `Backend CI` runs on every PR and direct push to non-`main` branches.
 - **Deploy trigger policy:** `Deploy Backend` runs on `main` pushes and manual `workflow_dispatch` from `main`; deploy is blocked unless backend tests pass.
 - **Control-plane guardrail:** `main` branch protection should require status check `Backend CI / backend-verify`.
@@ -325,6 +326,7 @@ back to socket peer IP to prevent header spoofing.
   - `done`: `{ "message_id": <int> }`
   - `error`: `{ "detail": "..." }` on failures
 - **Notes:** Uses a two-transaction pattern to avoid holding a DB session while streaming
+- **Production proxy note:** NGINX disables buffering and gzip on this path to preserve token-by-token SSE delivery
 
 #### GET /api/documents/{document_id}/messages
 - **Auth:** Required

--- a/docs/GCP_RUNBOOK.md
+++ b/docs/GCP_RUNBOOK.md
@@ -190,6 +190,7 @@ GHCR_TOKEN="<ghcr-token>" \
 3. Document flow:
    - upload PDF
    - status transitions from `pending/processing` to `completed`
+   - query stream renders token-by-token (not single buffered block)
    - query returns answer with sources
    - delete succeeds
 4. Worker:
@@ -204,6 +205,16 @@ GHCR_TOKEN="<ghcr-token>" \
 ```bash
 sudo nginx -t
 sudo systemctl status nginx --no-pager
+```
+
+## SSE proxy checks
+
+```bash
+# Confirm stream endpoint has anti-buffering directives
+sudo nginx -T | grep -E "query/stream|proxy_buffering off|X-Accel-Buffering|gzip off|proxy_read_timeout"
+
+# Apply config changes safely
+sudo nginx -t && sudo systemctl reload nginx
 ```
 
 ## Certbot status
@@ -292,6 +303,32 @@ Actions:
 2. Confirm Redis URL and connectivity.
 3. Verify `run-web-and-worker.sh` is startup command in running image.
 4. Restart container and retest upload.
+
+## Streaming answer arrives as one full block (no incremental tokens)
+
+Symptoms:
+
+- Frontend shows final answer all at once in production
+- Local streaming works token-by-token
+- `/query/stream` succeeds with `200` but cadence is lost
+
+Actions:
+
+1. Check NGINX stream-path directives are present:
+   - `proxy_buffering off`
+   - `proxy_cache off`
+   - `gzip off`
+   - `proxy_read_timeout 3600s`
+   - `add_header X-Accel-Buffering "no" always`
+2. Reload NGINX:
+   - `sudo nginx -t && sudo systemctl reload nginx`
+3. Re-run streaming query and inspect response headers in browser network tab:
+   - `content-type: text/event-stream`
+   - `x-accel-buffering: no`
+4. If still buffered, capture:
+   - `/var/log/nginx/error.log`
+   - `/var/log/nginx/access.log`
+   - browser request/response headers for `/api/documents/{id}/query/stream`
 
 ---
 

--- a/infra/terraform/scripts/startup.sh.tftpl
+++ b/infra/terraform/scripts/startup.sh.tftpl
@@ -33,10 +33,33 @@ if [[ ! -f "$${BOOTSTRAP_MARKER}" ]]; then
     curl -fsSL https://get.docker.com | sh
   fi
 
-  cat > "$${NGINX_SITE}" <<EOF
+  systemctl enable --now docker
+  systemctl enable --now certbot.timer || true
+  touch "$${BOOTSTRAP_MARKER}"
+fi
+
+# Always render the NGINX site so proxy updates apply to existing VMs too.
+cat > "$${NGINX_SITE}" <<EOF
 server {
     listen 80;
     server_name $${API_DOMAIN};
+
+    # Keep SSE responses truly streaming for the query stream endpoint.
+    location ~ ^/api/documents/[0-9]+/query/stream$ {
+        proxy_pass http://127.0.0.1:$${BACKEND_PORT};
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_buffering off;
+        proxy_cache off;
+        gzip off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        send_timeout 3600s;
+        add_header X-Accel-Buffering "no" always;
+    }
 
     location / {
         proxy_pass http://127.0.0.1:$${BACKEND_PORT};
@@ -49,16 +72,11 @@ server {
 }
 EOF
 
-  ln -sf "$${NGINX_SITE}" /etc/nginx/sites-enabled/quaero-backend
-  rm -f /etc/nginx/sites-enabled/default
-  nginx -t
-  systemctl enable --now nginx
-  systemctl restart nginx
-
-  systemctl enable --now docker
-  systemctl enable --now certbot.timer || true
-  touch "$${BOOTSTRAP_MARKER}"
-fi
+ln -sf "$${NGINX_SITE}" /etc/nginx/sites-enabled/quaero-backend
+rm -f /etc/nginx/sites-enabled/default
+nginx -t
+systemctl enable --now nginx
+systemctl restart nginx
 
 if [[ "$${ENABLE_TLS_BOOTSTRAP}" == "true" ]] && [[ -n "$${CERTBOT_EMAIL}" ]] && [[ ! -f "/etc/letsencrypt/live/$${API_DOMAIN}/fullchain.pem" ]]; then
   certbot --nginx --non-interactive --agree-tos \

--- a/plans/high-visibility-features/spec-phase-1-streaming.md
+++ b/plans/high-visibility-features/spec-phase-1-streaming.md
@@ -42,6 +42,7 @@ Add streaming RAG responses and pipeline observability metadata to Quaero. Users
 - [ ] Task: Streaming frontend (SSE consumer + ChatWindow + pipeline meta UI)
 - [ ] Task: Streaming frontend test coverage (SSE parser + stream lifecycle regression tests)
 - [ ] Task: High-value frontend regression tests (#50) (core auth/dashboard API-contract hardening ahead of Phase 2 UI work)
+- [ ] Task: NGINX SSE proxy hardening (#52) (production token-stream buffering fix)
 
 Split rationale: Backend contract should land and be testable before frontend integration. Frontend test coverage is a dedicated hardening task so later P1 changes can move faster with lower regression risk.
 

--- a/plans/high-visibility-features/task-phase-1-nginx-sse-proxy-hardening.md
+++ b/plans/high-visibility-features/task-phase-1-nginx-sse-proxy-hardening.md
@@ -1,0 +1,67 @@
+## Summary
+
+Fix production SSE delivery so streaming answers render token-by-token in the frontend instead of arriving as one buffered block.
+
+Parent Spec: #38
+Depends on: Streaming backend/frontend already shipped
+
+## What this delivers
+
+1. NGINX proxy configuration hardening for SSE (`/api/documents/{id}/query/stream`)
+2. Explicit anti-buffering and long-lived stream settings in VM bootstrap config
+3. Production verification steps proving first-token latency and incremental token delivery
+4. Runbook updates for future debugging of SSE buffering regressions
+
+## Problem Statement
+
+Local streaming works, but production shows full-response flush behavior:
+- `meta` timing appears, but answer text renders all at once
+- Network responses are `200` but token cadence is lost
+
+Most likely cause: reverse-proxy buffering/compression behavior between client and FastAPI stream response.
+
+## Acceptance Criteria
+
+- [ ] NGINX location handling API traffic disables response buffering for SSE traffic
+- [ ] SSE path supports long-lived responses without premature timeout/flush issues
+- [ ] Compression does not interfere with incremental token delivery
+- [ ] Streaming query in production visibly updates token-by-token (not full-block flush)
+- [ ] No regression for non-streaming API endpoints
+- [ ] `make backend-verify` still passes
+- [ ] Runbook contains explicit SSE troubleshooting checks (headers/logs/proxy config)
+
+## Implementation Notes
+
+- Keep routing contract unchanged (`POST /api/documents/{document_id}/query/stream`).
+- Prefer narrow proxy tuning for API/SSE behavior over broad global changes.
+- Validate with browser network timing + manual UX check.
+
+## Verification
+
+```bash
+make backend-verify
+```
+
+Operational checks after deploy:
+
+```bash
+curl -N -i https://api.quaero.odysian.dev/api/documents/<id>/query/stream
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+## Files in scope
+
+- `infra/terraform/scripts/startup.sh.tftpl`
+- `docs/GCP_RUNBOOK.md`
+- `docs/ARCHITECTURE.md` (if behavior/infra notes change)
+
+## Files explicitly out of scope
+
+- Query endpoint contract changes
+- Frontend rendering logic changes (unless needed for verification instrumentation)
+- New infrastructure services/load balancers/CDNs
+
+## Labels
+
+`type:task`, `area:backend`


### PR DESCRIPTION
## Summary
- harden NGINX proxy behavior for SSE so `/api/documents/{id}/query/stream` flushes incrementally in production
- disable buffering/cache/compression on the stream path and set stream-safe timeouts
- render the NGINX site config on every startup script execution so proxy updates apply to existing VMs
- document SSE smoke checks and incident handling in the GCP runbook
- link the new Phase 1 child task and add the dedicated task plan doc

## Testing
- make backend-verify
- bash -n infra/terraform/scripts/startup.sh.tftpl

Closes #52
