### PR TITLE
Task #59: redact upload_dir from /health responses

### DIFF
--- a/TESTPLAN.md
+++ b/TESTPLAN.md
@@ -69,6 +69,21 @@ Test case definitions for Quaero. Tests are defined here before implementation. 
 
 ---
 
+## Feature: Health Endpoint Redaction
+
+### Happy Path
+
+- GET `/health` returns 200 with `status=healthy` and `database=connected` when DB check succeeds
+- Health payload includes `max_file_size_mb` for operational visibility
+- Health payload does not expose filesystem path fields (`upload_dir`)
+
+### Error Cases
+
+- GET `/health` returns 503 with `status=unhealthy` and `database=error` when DB check fails
+- Unhealthy payload still omits filesystem path fields (`upload_dir`)
+
+---
+
 ## Feature: Document Upload
 
 ### Happy Path

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -106,7 +106,6 @@ async def health_check():
         return {
             "status": "healthy",
             "database": "connected",
-            "upload_dir": str(settings.get_upload_path()),
             "max_file_size_mb": settings.max_file_size / 1024 / 1024,
         }
     else:
@@ -115,7 +114,6 @@ async def health_check():
             content={
                 "status": "unhealthy",
                 "database": "error",
-                "upload_dir": str(settings.get_upload_path()),
                 "max_file_size_mb": settings.max_file_size / 1024 / 1024,
             },
         )

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,72 @@
+"""Tests for the /health endpoint response contract."""
+
+from unittest.mock import patch
+
+from app.config import settings
+
+
+class _HealthyConnection:
+    """Connection double that succeeds for SELECT 1 health probes."""
+
+    async def execute(self, _statement) -> None:  # type: ignore[no-untyped-def]
+        return None
+
+
+class _HealthyConnectionContext:
+    """Async context manager that yields a healthy connection."""
+
+    async def __aenter__(self) -> _HealthyConnection:
+        return _HealthyConnection()
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[no-untyped-def]
+        return False
+
+
+class _FailingConnectionContext:
+    """Async context manager that raises when connecting to the DB."""
+
+    async def __aenter__(self):  # type: ignore[no-untyped-def]
+        raise RuntimeError("database unavailable")
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[no-untyped-def]
+        return False
+
+
+class _HealthyEngine:
+    """Engine double that returns a healthy DB connection context."""
+
+    def connect(self) -> _HealthyConnectionContext:
+        return _HealthyConnectionContext()
+
+
+class _FailingEngine:
+    """Engine double that raises on DB connect."""
+
+    def connect(self) -> _FailingConnectionContext:
+        return _FailingConnectionContext()
+
+
+class TestHealthCheck:
+    """GET /health"""
+
+    async def test_health_success_redacts_upload_directory(self, client) -> None:
+        with patch("app.main.async_engine", new=_HealthyEngine()):
+            response = await client.get("/health")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["status"] == "healthy"
+        assert payload["database"] == "connected"
+        assert payload["max_file_size_mb"] == settings.max_file_size / 1024 / 1024
+        assert "upload_dir" not in payload
+
+    async def test_health_failure_redacts_upload_directory(self, client) -> None:
+        with patch("app.main.async_engine", new=_FailingEngine()):
+            response = await client.get("/health")
+
+        assert response.status_code == 503
+        payload = response.json()
+        assert payload["status"] == "unhealthy"
+        assert payload["database"] == "error"
+        assert payload["max_file_size_mb"] == settings.max_file_size / 1024 / 1024
+        assert "upload_dir" not in payload


### PR DESCRIPTION
## Summary
- remove `upload_dir` from healthy and unhealthy `/health` payloads
- keep status code and database connectivity semantics unchanged
- add dedicated health endpoint tests for both DB success/failure branches
- add TESTPLAN coverage for health payload redaction

## Verification
- make backend-verify

Closes #59
