### PR TITLE
Task #62: Redact raw query text from INFO logs

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -498,7 +498,9 @@ async def query_document(
     messages to the database for chat history.
     """
 
-    logger.info(f"Query request for document_id={document_id}: '{body.query}'")
+    logger.info(
+        f"Query request for document_id={document_id}, user_id={current_user.id}, query_chars={len(body.query)}"
+    )
 
     await _validate_document_for_query(
         document_id=document_id,
@@ -594,7 +596,9 @@ async def query_document_stream(
     """
     Stream an AI-generated answer over SSE for a document query.
     """
-    logger.info(f"Streaming query request for document_id={document_id}: '{body.query}'")
+    logger.info(
+        f"Streaming query request for document_id={document_id}, user_id={current_user.id}, query_chars={len(body.query)}"
+    )
 
     await _validate_document_for_query(
         document_id=document_id,

--- a/backend/app/services/anthropic_service.py
+++ b/backend/app/services/anthropic_service.py
@@ -63,7 +63,9 @@ async def generate_answer(query: str, chunks: list[dict]) -> str:
         "Based on the document, Q4 revenue was $5M..."
     """
 
-    logger.info(f"Generating answer for query: '{query}'")
+    logger.info(
+        f"Generating answer with query_chars={len(query)}, chunk_count={len(chunks)}"
+    )
 
     prompt = _build_prompt(query, chunks)
     logger.debug(f"Built prompt with {len(chunks)} chunks")
@@ -99,7 +101,9 @@ async def generate_answer_stream(query: str, chunks: list[dict]) -> AsyncGenerat
     """
     Calls Claude streaming API and yields answer tokens as they arrive.
     """
-    logger.info(f"Generating streaming answer for query: '{query}'")
+    logger.info(
+        f"Generating streaming answer with query_chars={len(query)}, chunk_count={len(chunks)}"
+    )
 
     prompt = _build_prompt(query, chunks)
     logger.debug(f"Built prompt with {len(chunks)} chunks")

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -12,7 +12,9 @@ async def search_chunks(query: str, document_id: int, top_k: int, db: AsyncSessi
     """
     Search for chunks semantically similar to the query.
     """
-    logger.info(f"Searching for: '{query}' in document_id={document_id}, top_k={top_k}")
+    logger.info(
+        f"Searching chunks for document_id={document_id}, top_k={top_k}, query_chars={len(query)}"
+    )
 
     query_embedding = await generate_embedding(query)
     logger.debug(f"Generated query embedding with {len(query_embedding)} dimensions")

--- a/backend/tests/test_anthropic_service_logging.py
+++ b/backend/tests/test_anthropic_service_logging.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.services.anthropic_service import generate_answer, generate_answer_stream
+
+
+class _FakeStreamContext:
+    def __init__(self, tokens: list[str]):
+        self._tokens = tokens
+
+    async def __aenter__(self) -> SimpleNamespace:
+        async def _token_stream():
+            for token in self._tokens:
+                yield token
+
+        return SimpleNamespace(text_stream=_token_stream())
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[no-untyped-def]
+        return False
+
+
+class TestAnthropicServiceLogging:
+    async def test_generate_answer_info_logs_redact_raw_query(self):
+        raw_query = "board compensation details"
+        chunks = [{"content": "Compensation details are in this excerpt."}]
+        response = SimpleNamespace(content=[SimpleNamespace(text="answer")])
+        create_mock = AsyncMock(return_value=response)
+        fake_client = SimpleNamespace(messages=SimpleNamespace(create=create_mock))
+
+        with (
+            patch("app.services.anthropic_service._get_client", return_value=fake_client),
+            patch("app.services.anthropic_service.logger.info") as mock_info,
+        ):
+            answer = await generate_answer(query=raw_query, chunks=chunks)
+
+        assert answer == "answer"
+        info_messages = [call.args[0] for call in mock_info.call_args_list]
+        assert any("query_chars=" in message for message in info_messages)
+        assert all(raw_query not in message for message in info_messages)
+
+    async def test_generate_answer_stream_info_logs_redact_raw_query(self):
+        raw_query = "future merger timeline"
+        chunks = [{"content": "Timeline details are in this excerpt."}]
+        stream_mock = MagicMock(return_value=_FakeStreamContext(["first", " second"]))
+        fake_client = SimpleNamespace(messages=SimpleNamespace(stream=stream_mock))
+
+        with (
+            patch("app.services.anthropic_service._get_client", return_value=fake_client),
+            patch("app.services.anthropic_service.logger.info") as mock_info,
+        ):
+            tokens = [token async for token in generate_answer_stream(query=raw_query, chunks=chunks)]
+
+        assert tokens == ["first", " second"]
+        info_messages = [call.args[0] for call in mock_info.call_args_list]
+        assert any("query_chars=" in message for message in info_messages)
+        assert all(raw_query not in message for message in info_messages)

--- a/backend/tests/test_query.py
+++ b/backend/tests/test_query.py
@@ -128,6 +128,22 @@ class TestSearch:
         )
         assert response.status_code == 404
 
+    async def test_search_info_logs_redact_raw_query(
+        self, client, auth_headers, processed_document, mock_embeddings
+    ):
+        raw_query = "salary details for q4"
+        with patch("app.services.search_service.logger.info") as mock_info:
+            response = await client.post(
+                f"/api/documents/{processed_document.id}/search",
+                headers=auth_headers,
+                json={"query": raw_query, "top_k": 3},
+            )
+
+        assert response.status_code == 200
+        info_messages = [call.args[0] for call in mock_info.call_args_list]
+        assert any("query_chars=" in message for message in info_messages)
+        assert all(raw_query not in message for message in info_messages)
+
 
 # ---------------------------------------------------------------------------
 # Query (RAG)
@@ -197,6 +213,31 @@ class TestQuery:
             json={"query": "test"},
         )
         assert response.status_code == 404
+
+    async def test_query_info_logs_redact_raw_query(
+        self,
+        client,
+        auth_headers,
+        processed_document,
+        mock_embeddings,
+        mock_anthropic,
+        test_user: User,
+    ):
+        raw_query = "sensitive compensation details"
+        with patch("app.api.documents.logger.info") as mock_info:
+            response = await client.post(
+                f"/api/documents/{processed_document.id}/query",
+                headers=auth_headers,
+                json={"query": raw_query},
+            )
+
+        assert response.status_code == 200
+        info_messages = [call.args[0] for call in mock_info.call_args_list]
+        assert any(
+            f"user_id={test_user.id}" in message and "query_chars=" in message
+            for message in info_messages
+        )
+        assert all(raw_query not in message for message in info_messages)
 
 
 # ---------------------------------------------------------------------------
@@ -288,6 +329,51 @@ class TestQueryStream:
             json={"query": "test"},
         )
         assert response.status_code == 400
+
+    async def test_stream_query_info_logs_redact_raw_query(
+        self,
+        client,
+        auth_headers,
+        processed_document,
+        mock_embeddings,
+        db_session: AsyncSession,
+        test_user: User,
+    ):
+        raw_query = "tell me internal budget notes"
+
+        async def _fake_generate_answer_stream(
+            query: str,
+            chunks: list[dict],
+        ) -> AsyncGenerator[str, None]:
+            del query, chunks
+            yield "streamed answer"
+
+        with (
+            patch("app.api.documents.logger.info") as mock_info,
+            patch(
+                "app.api.documents.generate_answer_stream",
+                new=_fake_generate_answer_stream,
+            ),
+            patch(
+                "app.api.documents.AsyncSessionLocal",
+                new=lambda: _NoCloseSessionContext(db_session),
+            ),
+        ):
+            async with client.stream(
+                "POST",
+                f"/api/documents/{processed_document.id}/query/stream",
+                headers=auth_headers,
+                json={"query": raw_query},
+            ) as response:
+                assert response.status_code == 200
+                await _read_sse_events(response)
+
+        info_messages = [call.args[0] for call in mock_info.call_args_list]
+        assert any(
+            f"user_id={test_user.id}" in message and "query_chars=" in message
+            for message in info_messages
+        )
+        assert all(raw_query not in message for message in info_messages)
 
     async def test_stream_query_emits_error_event_when_llm_stream_fails(
         self,

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -151,6 +151,11 @@ raise HTTPException(status_code=404, detail="Document not found")
 raise HTTPException(status_code=400, detail="Only PDF files are allowed")
 ```
 
+### Query Logging Redaction
+
+In query/search/LLM paths, INFO logs must not include raw user query text.
+Log metadata only (for example `document_id`, `user_id`, `query_chars`, `chunk_count`, `top_k`) and keep detailed exception context in error logs.
+
 ### Refresh Token Rotation
 
 The refresh endpoint consumes tokens with a single SQL statement (`DELETE ... RETURNING`) and commits exactly once after staging the replacement token.


### PR DESCRIPTION
## Summary
- redact INFO logs in query/search/LLM paths to remove raw query text
- keep observability via metadata fields (document_id, user_id, query_chars, chunk_count, top_k)
- add regression tests for route/service logging behavior and document the pattern

## Verification
- make backend-verify

Parent Spec: #58

Closes #62
