### PR TITLE
fix: normalize backend cache directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ verify: backend-verify frontend-verify ## Run all verification checks
 backend-verify: ## Lint, type-check, test, and security-scan the backend
 	@test -x backend/.venv/bin/ruff || (echo "Missing backend/.venv. Run: cd backend && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt" && exit 1)
 	@cd backend && \
-		.venv/bin/ruff check . && \
-		.venv/bin/mypy . --ignore-missing-imports --explicit-package-bases && \
-		.venv/bin/pytest -v && \
+		.venv/bin/ruff check . --cache-dir .ruff_cache && \
+		.venv/bin/mypy . --ignore-missing-imports --explicit-package-bases --cache-dir .mypy_cache && \
+		.venv/bin/pytest -v -o cache_dir=.pytest_cache && \
 		.venv/bin/bandit -r app/ -ll
 
 frontend-verify: ## Type-check, test, lint, and build the frontend

--- a/plans/fast-cache-layout-fix.md
+++ b/plans/fast-cache-layout-fix.md
@@ -1,0 +1,20 @@
+## Fast Kickoff: Backend Cache Layout Fix
+
+## Scope
+- Keep backend tool caches in `backend/` only.
+- Eliminate accidental nested cache output at `backend/backend/`.
+- Touch only cache configuration and backend verification command flags.
+
+## Checklist
+- [x] Update backend verify commands to use explicit cache directories relative to `backend/`.
+- [x] Align tool configuration so direct backend commands also write caches under `backend/`.
+- [x] Remove generated nested cache folder `backend/backend/`.
+- [x] Run backend verification once.
+
+## Verification
+```bash
+make backend-verify
+```
+
+## Suggested Commit Message
+`fix: normalize backend cache directories`

--- a/plans/pr-fast-cache-layout-fix.md
+++ b/plans/pr-fast-cache-layout-fix.md
@@ -1,0 +1,12 @@
+## Summary
+- normalize backend cache paths so lint/type/test cache artifacts stay under `backend/`
+- prevent accidental nested cache directory creation at `backend/backend/`
+- update backend verify commands to pass explicit cache dirs
+
+## Changes
+- `Makefile`: pass explicit cache flags for ruff/mypy/pytest in `backend-verify`
+- `pyproject.toml`: use local cache paths (`.ruff_cache`, `.mypy_cache`, `.pytest_cache`)
+- `plans/fast-cache-layout-fix.md`: fast-mode kickoff checklist
+
+## Verification
+- `make backend-verify` (pass)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.ruff]
-cache-dir = "backend/.ruff_cache"
+cache-dir = ".ruff_cache"
 
 [tool.mypy]
-cache_dir = "backend/.mypy_cache"
+cache_dir = ".mypy_cache"
 
 [tool.pytest.ini_options]
-cache_dir = "backend/.pytest_cache"
+cache_dir = ".pytest_cache"


### PR DESCRIPTION
## Summary
- normalize backend cache paths so lint/type/test cache artifacts stay under `backend/`
- prevent accidental nested cache directory creation at `backend/backend/`
- update backend verify commands to pass explicit cache dirs

## Changes
- `Makefile`: pass explicit cache flags for ruff/mypy/pytest in `backend-verify`
- `pyproject.toml`: use local cache paths (`.ruff_cache`, `.mypy_cache`, `.pytest_cache`)
- `plans/fast-cache-layout-fix.md`: fast-mode kickoff checklist

## Verification
- `make backend-verify` (pass)
