### PR TITLE
Task #100: Retrieval transparency debug panel

### DIFF
--- a/TESTPLAN.md
+++ b/TESTPLAN.md
@@ -161,7 +161,7 @@ Test case definitions for Quaero. Tests are defined here before implementation. 
 ### Happy Path
 
 - POST /api/documents/{id}/query with valid query returns answer with sources
-- POST /api/documents/{id}/query includes pipeline_meta timing/similarity fields
+- POST /api/documents/{id}/query includes pipeline_meta timing/similarity fields including `chunks_above_threshold`, `similarity_spread`, and `chat_history_turns_included`
 - POST /api/documents/{id}/query/stream returns SSE events in order: sources -> token* -> meta -> done
 - Answer includes cited chunks from the document
 - User message and assistant response are saved to messages table
@@ -198,6 +198,8 @@ Test case definitions for Quaero. Tests are defined here before implementation. 
 - ChatWindow send controls enter streaming state during an active stream and return to normal after `done`
 - ChatWindow shows a `Stop` control only during active streaming and aborts stream updates when clicked
 - ChatWindow `Retry` re-submits the same query after a stopped/failed assistant response and completes on `done`
+- Debug mode toggle persists in localStorage (`quaero_debug_mode`) and gates retrieval metadata visibility
+- When debug mode is on, assistant messages render pipeline metadata and citations render per-source similarity scores
 
 ### Error Cases
 
@@ -274,7 +276,7 @@ Test case definitions for Quaero. Tests are defined here before implementation. 
 
 - GET /api/documents/{id}/messages returns all messages for a document
 - Messages are ordered by created_at
-- Assistant messages include sources (JSONB)
+- Assistant messages include sources (JSONB) and optional `pipeline_meta` for historical debug rendering
 
 ### Error Cases
 

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -3,6 +3,7 @@ import time
 from collections.abc import AsyncGenerator
 from urllib.parse import quote
 
+from pydantic import ValidationError
 from app.api.dependencies import get_current_user
 from app.database import AsyncSessionLocal, get_db
 from app.models.base import Chunk, Document, DocumentStatus
@@ -35,6 +36,7 @@ logger = get_logger(__name__)
 
 router = APIRouter()
 CONVERSATION_HISTORY_WINDOW_TURNS = 5
+SIMILARITY_THRESHOLD = 0.75
 
 
 def _elapsed_ms(start_time: float) -> int:
@@ -63,6 +65,7 @@ def _encode_sse_event(event: ServerSentEvent) -> bytes:
 def _build_pipeline_meta(
     *,
     search_results: list[dict],
+    conversation_history: list[dict[str, str]],
     embed_ms: int,
     retrieval_ms: int,
     llm_ms: int,
@@ -71,6 +74,7 @@ def _build_pipeline_meta(
     similarities = [result["similarity"] for result in search_results]
     top_similarity = max(similarities) if similarities else 0.0
     avg_similarity = (sum(similarities) / len(similarities)) if similarities else 0.0
+    similarity_spread = (max(similarities) - min(similarities)) if similarities else 0.0
 
     return PipelineMeta(
         embed_ms=embed_ms,
@@ -80,7 +84,45 @@ def _build_pipeline_meta(
         top_similarity=round(top_similarity, 4),
         avg_similarity=round(avg_similarity, 4),
         chunks_retrieved=len(search_results),
+        chunks_above_threshold=sum(
+            1 for similarity in similarities if similarity > SIMILARITY_THRESHOLD
+        ),
+        similarity_spread=round(similarity_spread, 4),
+        chat_history_turns_included=len(conversation_history) // 2,
     )
+
+
+def _build_message_sources_payload(
+    *,
+    sources: list[dict],
+    pipeline_meta: PipelineMeta | None,
+) -> dict:
+    payload: dict = {"sources": sources}
+    if pipeline_meta is not None:
+        payload["pipeline_meta"] = pipeline_meta.model_dump()
+    return payload
+
+
+def _extract_sources_and_pipeline_meta(raw_sources: object) -> tuple[list[dict] | None, PipelineMeta | None]:
+    if isinstance(raw_sources, list):
+        return raw_sources, None
+
+    if not isinstance(raw_sources, dict):
+        return None, None
+
+    sources_payload = raw_sources.get("sources")
+    sources = sources_payload if isinstance(sources_payload, list) else None
+
+    pipeline_meta_payload = raw_sources.get("pipeline_meta")
+    if not isinstance(pipeline_meta_payload, dict):
+        return sources, None
+
+    try:
+        pipeline_meta = PipelineMeta.model_validate(pipeline_meta_payload)
+    except ValidationError:
+        pipeline_meta = None
+
+    return sources, pipeline_meta
 
 
 async def _search_chunks_from_embedding(
@@ -604,6 +646,7 @@ async def query_document(
         sources = [SearchResult(**result) for result in search_results]
         pipeline_meta = _build_pipeline_meta(
             search_results=search_results,
+            conversation_history=conversation_history,
             embed_ms=embed_ms,
             retrieval_ms=retrieval_ms,
             llm_ms=llm_ms,
@@ -618,7 +661,10 @@ async def query_document(
             user_id=current_user.id,
             role="assistant",
             content=answer,
-            sources=sources_dict,
+            sources=_build_message_sources_payload(
+                sources=sources_dict,
+                pipeline_meta=pipeline_meta,
+            ),
         )
         db.add(assistant_message)
         await db.commit()
@@ -727,7 +773,7 @@ async def query_document_stream(
         async def _persist_assistant_message(
             *,
             content: str,
-            sources_payload: list[dict] | None,
+            sources_payload: dict | None,
         ) -> int | None:
             try:
                 async with AsyncSessionLocal() as write_db:
@@ -781,7 +827,10 @@ async def query_document_stream(
             )
             await _persist_assistant_message(
                 content=assistant_content,
-                sources_payload=sources_dict,
+                sources_payload=_build_message_sources_payload(
+                    sources=sources_dict,
+                    pipeline_meta=None,
+                ),
             )
             yield ServerSentEvent(event="error", raw_data=json.dumps({"detail": "Query failed"}))
             return
@@ -789,6 +838,7 @@ async def query_document_stream(
         llm_ms = _elapsed_ms(llm_start)
         pipeline_meta = _build_pipeline_meta(
             search_results=search_results,
+            conversation_history=conversation_history,
             embed_ms=embed_ms,
             retrieval_ms=retrieval_ms,
             llm_ms=llm_ms,
@@ -799,7 +849,10 @@ async def query_document_stream(
         answer = "".join(answer_tokens)
         assistant_message_id = await _persist_assistant_message(
             content=answer,
-            sources_payload=sources_dict,
+            sources_payload=_build_message_sources_payload(
+                sources=sources_dict,
+                pipeline_meta=pipeline_meta,
+            ),
         )
         if assistant_message_id is None:
             # Best effort fallback so chat history still has a terminal assistant turn.
@@ -856,7 +909,23 @@ async def get_document_messages(
     )
     messages = (await db.scalars(msg_stmt)).all()
 
+    response_messages: list[MessageResponse] = []
+    for msg in messages:
+        sources, pipeline_meta = _extract_sources_and_pipeline_meta(msg.sources)
+        response_messages.append(
+            MessageResponse(
+                id=msg.id,
+                document_id=msg.document_id,
+                user_id=msg.user_id,
+                role=msg.role,
+                content=msg.content,
+                sources=sources,
+                pipeline_meta=pipeline_meta,
+                created_at=msg.created_at,
+            )
+        )
+
     return MessageListResponse(
-        messages=[MessageResponse.model_validate(msg) for msg in messages],
+        messages=response_messages,
         total=len(messages),
     )

--- a/backend/app/schemas/message.py
+++ b/backend/app/schemas/message.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import List, Optional
 
 from pydantic import BaseModel, Field
+from app.schemas.query import PipelineMeta
 
 
 class MessageSource(BaseModel):
@@ -28,7 +29,7 @@ class MessageCreate(MessageBase):
 
     document_id: int
     user_id: int
-    sources: Optional[List[dict]] = None
+    sources: Optional[dict | List[dict]] = None
 
 
 class MessageResponse(MessageBase):
@@ -38,6 +39,7 @@ class MessageResponse(MessageBase):
     document_id: int
     user_id: int
     sources: Optional[List[dict]] = None
+    pipeline_meta: PipelineMeta | None = None
     created_at: datetime
 
     class Config:

--- a/backend/app/schemas/query.py
+++ b/backend/app/schemas/query.py
@@ -19,6 +19,9 @@ class PipelineMeta(BaseModel):
     top_similarity: float
     avg_similarity: float
     chunks_retrieved: int
+    chunks_above_threshold: int
+    similarity_spread: float
+    chat_history_turns_included: int
 
 
 class QueryResponse(BaseModel):

--- a/backend/tests/test_query.py
+++ b/backend/tests/test_query.py
@@ -205,6 +205,9 @@ class TestQuery:
         assert isinstance(data["sources"], list)
         assert "pipeline_meta" in data
         assert data["pipeline_meta"]["chunks_retrieved"] == len(data["sources"])
+        assert "chunks_above_threshold" in data["pipeline_meta"]
+        assert "similarity_spread" in data["pipeline_meta"]
+        assert "chat_history_turns_included" in data["pipeline_meta"]
 
     async def test_query_saves_user_and_assistant_messages(
         self,
@@ -236,8 +239,10 @@ class TestQuery:
         assert messages[0].content == "Tell me about the content"
         assert messages[1].role == "assistant"
         assert len(messages[1].content) > 0
-        # Assistant message should have sources stored as JSONB
-        assert messages[1].sources is not None
+        # Assistant message stores sources plus pipeline metadata in JSONB.
+        assert isinstance(messages[1].sources, dict)
+        assert isinstance(messages[1].sources.get("sources"), list)
+        assert isinstance(messages[1].sources.get("pipeline_meta"), dict)
 
     async def test_query_passes_bounded_ordered_history_to_prompt(
         self,
@@ -429,6 +434,9 @@ class TestQueryStream:
             "top_similarity",
             "avg_similarity",
             "chunks_retrieved",
+            "chunks_above_threshold",
+            "similarity_spread",
+            "chat_history_turns_included",
         }
 
         done_payload = json.loads(events[5][1])
@@ -805,7 +813,21 @@ class TestMessages:
             user_id=test_user.id,
             role="assistant",
             content="This is a test document.",
-            sources=[{"chunk_id": 1, "content": "test", "similarity": 0.9, "chunk_index": 0}],
+            sources={
+                "sources": [{"chunk_id": 1, "content": "test", "similarity": 0.9, "chunk_index": 0}],
+                "pipeline_meta": {
+                    "embed_ms": 10,
+                    "retrieval_ms": 20,
+                    "llm_ms": 30,
+                    "total_ms": 60,
+                    "top_similarity": 0.9,
+                    "avg_similarity": 0.9,
+                    "chunks_retrieved": 1,
+                    "chunks_above_threshold": 1,
+                    "similarity_spread": 0.0,
+                    "chat_history_turns_included": 0,
+                },
+            },
         )
         db_session.add(user_msg)
         db_session.add(asst_msg)
@@ -822,6 +844,7 @@ class TestMessages:
         assert data["messages"][0]["role"] == "user"
         assert data["messages"][1]["role"] == "assistant"
         assert data["messages"][1]["sources"] is not None
+        assert data["messages"][1]["pipeline_meta"]["chunks_above_threshold"] == 1
 
     async def test_get_messages_returns_empty_for_no_messages(
         self, client, auth_headers, processed_document
@@ -835,6 +858,35 @@ class TestMessages:
         data = response.json()
         assert data["total"] == 0
         assert data["messages"] == []
+
+    async def test_get_messages_supports_legacy_sources_payload(
+        self,
+        client,
+        auth_headers,
+        processed_document,
+        db_session: AsyncSession,
+        test_user: User,
+    ):
+        db_session.add(
+            Message(
+                document_id=processed_document.id,
+                user_id=test_user.id,
+                role="assistant",
+                content="Legacy message",
+                sources=[{"chunk_id": 1, "content": "legacy", "similarity": 0.8, "chunk_index": 0}],
+            )
+        )
+        await db_session.flush()
+
+        response = await client.get(
+            f"/api/documents/{processed_document.id}/messages",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["messages"][0]["sources"] is not None
+        assert data["messages"][0]["pipeline_meta"] is None
 
     async def test_get_messages_returns_404_for_other_users_document(
         self, client, second_user_headers, processed_document

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,7 +148,7 @@ All tables live in the `quaero` schema for isolation on shared PostgreSQL.
 | user_id | INTEGER | FK → users.id, ON DELETE CASCADE |
 | role | VARCHAR(20) | NOT NULL, CHECK IN ('user', 'assistant') |
 | content | TEXT | NOT NULL |
-| sources | JSONB | nullable (search results for assistant messages) |
+| sources | JSONB | nullable (assistant payload: `sources[]` and optional `pipeline_meta`) |
 | created_at | TIMESTAMP | DEFAULT now(), NOT NULL |
 
 ### refresh_tokens
@@ -323,7 +323,7 @@ back to socket peer IP to prevent header spoofing.
 - **Auth:** Required
 - **Rate Limit:** 10/hour per user/IP
 - **Request Body:** `{ "query": "string" }`
-- **Success (200):** `{ "query": "...", "answer": "...", "sources": [...], "pipeline_meta": { "embed_ms": 12, "retrieval_ms": 8, "llm_ms": 420, "total_ms": 440, "top_similarity": 0.91, "avg_similarity": 0.82, "chunks_retrieved": 5 } }`
+- **Success (200):** `{ "query": "...", "answer": "...", "sources": [...], "pipeline_meta": { "embed_ms": 12, "retrieval_ms": 8, "llm_ms": 420, "total_ms": 440, "top_similarity": 0.91, "avg_similarity": 0.82, "chunks_retrieved": 5, "chunks_above_threshold": 4, "similarity_spread": 0.12, "chat_history_turns_included": 3 } }`
 - **Notes:** Full RAG pipeline — loads bounded recent chat history (oldest -> newest), embeds query, searches chunks, sends to Claude, saves messages
 - **Errors:**
   - 404: Document not found
@@ -335,7 +335,7 @@ back to socket peer IP to prevent header spoofing.
 - **Success (200):** `text/event-stream` with ordered events:
   - `sources`: JSON array of search results
   - `token`: streamed answer token text
-  - `meta`: pipeline metadata (`embed_ms`, `retrieval_ms`, `llm_ms`, `total_ms`, `top_similarity`, `avg_similarity`, `chunks_retrieved`)
+  - `meta`: pipeline metadata (`embed_ms`, `retrieval_ms`, `llm_ms`, `total_ms`, `top_similarity`, `avg_similarity`, `chunks_retrieved`, `chunks_above_threshold`, `similarity_spread`, `chat_history_turns_included`)
   - `done`: `{ "message_id": <int> }`
   - `error`: `{ "detail": "..." }` on failures
 - **Notes:** Uses a two-transaction pattern to avoid holding a DB session while streaming; includes the same bounded recent chat history window used by `/query`
@@ -344,7 +344,7 @@ back to socket peer IP to prevent header spoofing.
 #### GET /api/documents/{document_id}/messages
 - **Auth:** Required
 - **Rate Limit:** 30/hour per user/IP
-- **Success (200):** `{ "messages": [{ "id": 1, "role": "user", "content": "...", "sources": [...], "created_at": "..." }] }`
+- **Success (200):** `{ "messages": [{ "id": 1, "role": "assistant", "content": "...", "sources": [...], "pipeline_meta": { ... }, "created_at": "..." }] }`
 - **Notes:** Returns chat history for a specific document
 
 ---

--- a/frontend/app/components/dashboard/ChatWindow.tsx
+++ b/frontend/app/components/dashboard/ChatWindow.tsx
@@ -6,7 +6,7 @@
 "use client";
 
 import { useState, useRef, useEffect, SyntheticEvent } from "react";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Settings2 } from "lucide-react";
 import {
   type Document,
   api,
@@ -43,6 +43,7 @@ const SUGGESTED_PROMPTS = [
   "What are the main points?",
   "Find key dates or numbers",
 ];
+const DEBUG_MODE_STORAGE_KEY = "quaero_debug_mode";
 
 /**
  * Renders the pop up window with query input and message history.
@@ -56,11 +57,9 @@ export function ChatWindow({
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const [loadingHistory, setLoadingHistory] = useState(true);
+  const [debugMode, setDebugMode] = useState(false);
   const [expandedSourceIndices, setExpandedSourceIndices] = useState<Set<number>>(new Set());
   const [expandedSourceCards, setExpandedSourceCards] = useState<Set<string>>(new Set());
-  const [expandedPipelineMetaIndices, setExpandedPipelineMetaIndices] = useState<Set<number>>(
-    new Set()
-  );
   const scrollRef = useRef<HTMLDivElement>(null);
   const isMountedRef = useRef(true);
   const activeStreamAbortRef = useRef<AbortController | null>(null);
@@ -98,14 +97,12 @@ export function ChatWindow({
     });
   };
 
-  /** Toggle pipeline timing metadata for an assistant message. */
-  const togglePipelineMeta = (messageIndex: number) => {
-    setExpandedPipelineMetaIndices((prev) => {
-      const next = new Set(prev);
-      if (next.has(messageIndex)) next.delete(messageIndex);
-      else next.add(messageIndex);
-      return next;
-    });
+  const toggleDebugMode = () => {
+    const nextDebugMode = !debugMode;
+    setDebugMode(nextDebugMode);
+    if (typeof window !== "undefined") {
+      localStorage.setItem(DEBUG_MODE_STORAGE_KEY, nextDebugMode ? "true" : "false");
+    }
   };
 
   const updateStreamingAssistant = (updater: (message: Message) => Message) => {
@@ -166,6 +163,11 @@ export function ChatWindow({
     };
   }, []);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setDebugMode(localStorage.getItem(DEBUG_MODE_STORAGE_KEY) === "true");
+  }, []);
+
 
   useEffect(() => {
     const loadHistory = async () => {
@@ -177,6 +179,7 @@ export function ChatWindow({
           role: msg.role,
           content: msg.content,
           sources: msg.sources as QueryResponse["sources"],
+          pipeline_meta: msg.pipeline_meta,
         }));
         setMessages(loadedMessages);
       } catch (err) {
@@ -310,6 +313,12 @@ export function ChatWindow({
     return `Pages ${pageStart}-${pageEnd}`;
   };
 
+  const getConfidence = (topSimilarity: number): "high" | "medium" | "low" => {
+    if (topSimilarity >= 0.85) return "high";
+    if (topSimilarity >= 0.7) return "medium";
+    return "low";
+  };
+
   return (
     <div className="flex flex-col w-full h-full min-h-0 max-h-full bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden shadow-xl">
       {/* Header */}
@@ -334,6 +343,19 @@ export function ChatWindow({
             </p>
           </div>
         </div>
+        <button
+          type="button"
+          onClick={toggleDebugMode}
+          aria-pressed={debugMode}
+          className={`ml-3 shrink-0 inline-flex items-center gap-1 rounded-lg border px-2.5 py-1.5 text-xs transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-lapis-500 focus:ring-offset-2 focus:ring-offset-zinc-900 ${
+            debugMode
+              ? "border-lapis-500/60 bg-lapis-500/10 text-lapis-300"
+              : "border-zinc-700 text-zinc-400 hover:text-zinc-200 hover:border-zinc-500"
+          }`}
+        >
+          <Settings2 size={14} aria-hidden />
+          <span>{debugMode ? "Debug on" : "Debug off"}</span>
+        </button>
       </div>
 
       {/* Messages Area */}
@@ -437,15 +459,11 @@ export function ChatWindow({
               )}
             </div>
 
-            {msg.role === "assistant" && msg.pipeline_meta && (
-              <div className="mt-2 ml-2 max-w-[85%] text-xs text-zinc-500">
-                <button
-                  type="button"
-                  onClick={() => togglePipelineMeta(i)}
-                  className="flex items-center gap-2 hover:text-zinc-300 transition-colors cursor-pointer"
-                >
+            {debugMode && msg.role === "assistant" && msg.pipeline_meta && (
+              <details className="mt-2 ml-2 max-w-[85%] text-xs text-zinc-400 group">
+                <summary className="cursor-pointer list-none flex items-center gap-2 hover:text-zinc-200 transition-colors">
                   <svg
-                    className={`w-3 h-3 shrink-0 transition-transform ${expandedPipelineMetaIndices.has(i) ? "rotate-90" : ""}`}
+                    className="w-3 h-3 shrink-0 transition-transform group-open:rotate-90"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -462,25 +480,24 @@ export function ChatWindow({
                     {(msg.pipeline_meta.total_ms / 1000).toFixed(1)}s ·{" "}
                     {(msg.pipeline_meta.avg_similarity * 100).toFixed(0)}% retrieval ·{" "}
                     {msg.pipeline_meta.chunks_retrieved}{" "}
-                    {msg.pipeline_meta.chunks_retrieved === 1 ? "source" : "sources"}
+                    {msg.pipeline_meta.chunks_retrieved === 1 ? "source" : "sources"} ·{" "}
+                    {getConfidence(msg.pipeline_meta.top_similarity)} confidence
                   </span>
-                </button>
-
-                {expandedPipelineMetaIndices.has(i) && (
-                  <div className="mt-2 ml-5 space-y-1">
-                    <p>Embedding: {msg.pipeline_meta.embed_ms}ms</p>
-                    <p>
-                      Retrieval: {msg.pipeline_meta.retrieval_ms}ms (
-                      {msg.pipeline_meta.chunks_retrieved} chunks,{" "}
-                      {(msg.pipeline_meta.avg_similarity * 100).toFixed(0)}% avg)
-                    </p>
-                    <p>Generation: {msg.pipeline_meta.llm_ms}ms</p>
-                    <div className="border-t border-zinc-700/50 pt-1 mt-1">
-                      <p>Total: {msg.pipeline_meta.total_ms}ms</p>
-                    </div>
+                </summary>
+                <div className="mt-2 ml-5 space-y-1">
+                  <p>Embedding: {msg.pipeline_meta.embed_ms}ms</p>
+                  <p>Retrieval: {msg.pipeline_meta.retrieval_ms}ms</p>
+                  <p>Generation: {msg.pipeline_meta.llm_ms}ms</p>
+                  <p>Top similarity: {(msg.pipeline_meta.top_similarity * 100).toFixed(1)}%</p>
+                  <p>Average similarity: {(msg.pipeline_meta.avg_similarity * 100).toFixed(1)}%</p>
+                  <p>Chunks above 0.75: {msg.pipeline_meta.chunks_above_threshold}</p>
+                  <p>Similarity spread: {(msg.pipeline_meta.similarity_spread * 100).toFixed(1)}%</p>
+                  <p>History turns included: {msg.pipeline_meta.chat_history_turns_included}</p>
+                  <div className="border-t border-zinc-700/50 pt-1 mt-1">
+                    <p>Total: {msg.pipeline_meta.total_ms}ms</p>
                   </div>
-                )}
-              </div>
+                </div>
+              </details>
             )}
 
             {msg.role === "assistant" && msg.retry_query && !msg.streaming && (
@@ -565,9 +582,11 @@ export function ChatWindow({
                             <span className="badge-sm bg-lapis-600 text-white px-2 py-0.5 rounded">
                               {idx + 1}
                             </span>
-                            <span className="text-meta-bright">
-                              Relevance: {(source.similarity * 100).toFixed(0)}%
-                            </span>
+                            {debugMode && (
+                              <span className="text-meta-bright">
+                                Similarity: {(source.similarity * 100).toFixed(1)}%
+                              </span>
+                            )}
                             <span className="text-meta-bright">
                               Excerpt {source.chunk_index}
                             </span>

--- a/frontend/app/components/dashboard/__tests__/ChatWindow.streaming.test.tsx
+++ b/frontend/app/components/dashboard/__tests__/ChatWindow.streaming.test.tsx
@@ -321,4 +321,55 @@ describe("ChatWindow streaming lifecycle", () => {
       snippet: "Cited section content for pages three and four.",
     });
   });
+
+  it("toggles debug mode and shows pipeline metadata/similarity from history", async () => {
+    localStorage.removeItem("quaero_debug_mode");
+    getMessagesMock.mockResolvedValueOnce({
+      messages: [
+        {
+          id: 2,
+          document_id: documentFixture.id,
+          user_id: documentFixture.user_id,
+          role: "assistant",
+          content: "Debuggable answer.",
+          sources: [
+            {
+              chunk_id: 3,
+              content: "Debug source content.",
+              similarity: 0.91,
+              chunk_index: 0,
+            },
+          ],
+          pipeline_meta: {
+            embed_ms: 11,
+            retrieval_ms: 12,
+            llm_ms: 13,
+            total_ms: 36,
+            top_similarity: 0.91,
+            avg_similarity: 0.89,
+            chunks_retrieved: 1,
+            chunks_above_threshold: 1,
+            similarity_spread: 0,
+            chat_history_turns_included: 2,
+          },
+          created_at: "2026-03-02T12:02:00Z",
+        },
+      ],
+      total: 1,
+    });
+
+    render(<ChatWindow document={documentFixture} onBack={vi.fn()} />);
+    await screen.findByText("Debuggable answer.");
+
+    fireEvent.click(screen.getByRole("button", { name: "Sources (1)" }));
+    expect(screen.queryByText(/Similarity:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/confidence/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Debug off" }));
+
+    expect(screen.getByRole("button", { name: "Debug on" })).toBeInTheDocument();
+    expect(localStorage.getItem("quaero_debug_mode")).toBe("true");
+    expect(screen.getByText(/confidence/)).toBeInTheDocument();
+    expect(screen.getByText("Similarity: 91.0%")).toBeInTheDocument();
+  });
 });

--- a/frontend/lib/__tests__/api.queryDocumentStream.test.ts
+++ b/frontend/lib/__tests__/api.queryDocumentStream.test.ts
@@ -33,7 +33,8 @@ describe("api.queryDocumentStream", () => {
         "event: token\ndata: Hel",
         "lo\n\n",
         "event: meta\ndata: {\"embed_ms\":12,\"retrieval_ms\":8,",
-        "\"llm_ms\":40,\"total_ms\":60,\"top_similarity\":0.91,\"avg_similarity\":0.88,\"chunks_retrieved\":1}\n\n",
+        "\"llm_ms\":40,\"total_ms\":60,\"top_similarity\":0.91,\"avg_similarity\":0.88,\"chunks_retrieved\":1,",
+        "\"chunks_above_threshold\":1,\"similarity_spread\":0,\"chat_history_turns_included\":2}\n\n",
         "event: done\ndata: {\"message_id\":77}\n\n",
       ])
     );
@@ -83,6 +84,9 @@ describe("api.queryDocumentStream", () => {
         top_similarity: 0.91,
         avg_similarity: 0.88,
         chunks_retrieved: 1,
+        chunks_above_threshold: 1,
+        similarity_spread: 0,
+        chat_history_turns_included: 2,
       },
     ]);
     expect(donePayloads).toEqual([{ message_id: 77 }]);

--- a/frontend/lib/api.types.ts
+++ b/frontend/lib/api.types.ts
@@ -96,6 +96,9 @@ export interface PipelineMeta {
   top_similarity: number;
   avg_similarity: number;
   chunks_retrieved: number;
+  chunks_above_threshold: number;
+  similarity_spread: number;
+  chat_history_turns_included: number;
 }
 
 // Messages
@@ -106,6 +109,7 @@ export interface MessageResponse {
   role: "user" | "assistant";
   content: string;
   sources?: SearchResult[];
+  pipeline_meta?: PipelineMeta;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary
- add localStorage-backed `quaero_debug_mode` toggle in ChatWindow and gate debug UI to that mode
- extend backend `PipelineMeta` with `chunks_above_threshold`, `similarity_spread`, and `chat_history_turns_included`
- persist assistant message debug payload in `messages.sources` as `{ sources, pipeline_meta }` and expose `pipeline_meta` from `/messages`
- keep backward compatibility for legacy message rows where `sources` is stored as a plain list
- update backend/frontend tests and architecture/testplan docs for the updated metadata contract

## Verification
- `make backend-verify`
- `make frontend-verify`

Closes #100
