### PR TITLE
Task #114: Mentored ports/adapters slice for document upload/process

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -4,8 +4,25 @@ from collections.abc import AsyncGenerator
 from urllib.parse import quote
 
 from pydantic import ValidationError
+from app.application.documents.use_cases import (
+    DemoUploadForbiddenError,
+    DocumentAlreadyProcessedError,
+    DocumentAlreadyProcessingError,
+    DocumentNotFoundError,
+    DocumentQueueUnavailableError,
+    ProcessDocumentCommand,
+    ProcessDocumentUseCase,
+    ProcessQueueUnavailableError,
+    UploadDocumentCommand,
+    UploadDocumentUseCase,
+)
 from app.api.dependencies import get_current_user
 from app.database import AsyncSessionLocal, get_db
+from app.infrastructure.documents.adapters import (
+    FileUtilsUploadStorageAdapter,
+    QueueServiceAdapter,
+    SQLAlchemyDocumentCommandAdapter,
+)
 from app.models.base import Chunk, Document, DocumentStatus
 from app.models.message import Message
 from app.models.user import User
@@ -23,7 +40,6 @@ from app.services.embedding_service import generate_embedding
 from app.services.queue_service import enqueue_document_processing
 from app.services.search_service import search_chunks
 from app.services.storage_service import delete_file, read_file_bytes
-from app.utils.file_utils import save_upload_file, validate_file_upload
 from app.utils.logging_config import get_logger
 from app.utils.rate_limit import get_user_or_ip_key, limiter
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
@@ -250,51 +266,48 @@ async def upload_document(
     3. Create database record
     4. Return document info
     """
-    if current_user.is_demo:
+    logger.info(f"Uploading: {file.filename}")
+
+    use_case = UploadDocumentUseCase(
+        storage=FileUtilsUploadStorageAdapter(),
+        documents=SQLAlchemyDocumentCommandAdapter(db=db),
+        queue=QueueServiceAdapter(
+            enqueue_document_processing_fn=enqueue_document_processing,
+        ),
+    )
+
+    try:
+        result = await use_case.execute(
+            UploadDocumentCommand(
+                user_id=current_user.id,
+                user_is_demo=current_user.is_demo,
+                upload_file=file,
+            )
+        )
+    except DemoUploadForbiddenError:
         raise HTTPException(
             status_code=403,
             detail="Demo account cannot upload documents",
         )
-
-    logger.info(f"Uploading: {file.filename}")
-
-    validate_file_upload(file)
-
-    file_path, file_size = await save_upload_file(file)
-
-    document = Document(
-        filename=file.filename,
-        file_path=file_path,
-        file_size=file_size,
-        status=DocumentStatus.PENDING,
-        user_id=current_user.id,
-    )
-
-    db.add(document)
-    await db.commit()
-    await db.refresh(document)  # Get auto-generated ID
-    try:
-        await enqueue_document_processing(document.id)
-    except Exception as exc:
-        # Persist queue failure on the document so the user can retry explicitly.
-        document.status = DocumentStatus.FAILED
-        document.error_message = "Upload succeeded, but queueing failed. Please retry."
-        await db.commit()
-        logger.error(f"Queueing failed for document_id={document.id}: {exc}", exc_info=True)
+    except DocumentQueueUnavailableError as exc:
+        logger.error(
+            f"Queueing failed for document_id={exc.document_id}",
+            exc_info=True,
+        )
         raise HTTPException(
             status_code=503,
             detail="Document uploaded but could not be queued for processing.",
         )
 
-    logger.info(f"Upload complete and queued: document_id={document.id}")
+    logger.info(f"Upload complete and queued: document_id={result.id}")
 
     return UploadResponse(
-        id=document.id,
-        user_id=current_user.id,
-        filename=document.filename,
-        file_size=document.file_size,
-        status=document.status,
-        message="File uploaded successfully. Processing started in background.",
+        id=result.id,
+        user_id=result.user_id,
+        filename=result.filename,
+        file_size=result.file_size,
+        status=result.status,
+        message=result.message,
     )
 
 
@@ -483,53 +496,39 @@ async def process_document(
     """
     logger.info(f"Queue processing request for document_id={document_id}")
 
-    stmt = (
-        select(Document)
-        .where(Document.id == document_id)
-        .where(Document.user_id == current_user.id)
+    use_case = ProcessDocumentUseCase(
+        documents=SQLAlchemyDocumentCommandAdapter(db=db),
+        queue=QueueServiceAdapter(
+            enqueue_document_processing_fn=enqueue_document_processing,
+        ),
     )
-    document = await db.scalar(stmt)
 
-    if not document:
+    try:
+        result = await use_case.execute(
+            ProcessDocumentCommand(
+                document_id=document_id,
+                user_id=current_user.id,
+            )
+        )
+    except DocumentNotFoundError:
         raise HTTPException(
             status_code=404, detail=f"Document with ID {document_id} not found"
         )
-
-    if document.status == DocumentStatus.COMPLETED:
+    except DocumentAlreadyProcessedError:
         raise HTTPException(status_code=400, detail=f"Document {document_id} already processed")
-
-    if document.status == DocumentStatus.PROCESSING:
+    except DocumentAlreadyProcessingError:
         raise HTTPException(
             status_code=400,
             detail=f"Document {document_id} is currently being processed",
         )
-
-    if document.status == DocumentStatus.FAILED:
-        # Reset stale failure details before retry.
-        document.status = DocumentStatus.PENDING
-        document.error_message = None
-        document.processed_at = None
-        await db.commit()
-
-    try:
-        enqueued = await enqueue_document_processing(document_id)
-    except Exception as exc:
-        document.status = DocumentStatus.FAILED
-        document.error_message = "Queueing failed. Please retry processing."
-        await db.commit()
+    except ProcessQueueUnavailableError as exc:
         logger.error(
-            f"Failed to enqueue document_id={document_id}: {exc}",
+            f"Failed to enqueue document_id={exc.document_id}",
             exc_info=True,
         )
         raise HTTPException(status_code=503, detail="Failed to queue document processing")
 
-    message = (
-        f"Document {document_id} processing already queued"
-        if not enqueued
-        else f"Document {document_id} queued for background processing"
-    )
-
-    return {"message": message, "document_id": document_id}
+    return {"message": result.message, "document_id": result.document_id}
 
 
 @router.post("/{document_id}/search", response_model=SearchResponse)

--- a/backend/app/application/documents/ports.py
+++ b/backend/app/application/documents/ports.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+from app.models.base import DocumentStatus
+
+
+class UploadFileLike(Protocol):
+    """Transport-agnostic subset needed for upload validation/storage."""
+
+    filename: str | None
+    content_type: str | None
+    size: int | None
+
+    async def read(self, size: int = -1) -> bytes: ...
+
+
+@dataclass(slots=True)
+class StoredUpload:
+    filename: str
+    file_path: str
+    file_size: int
+
+
+@dataclass(slots=True)
+class DocumentRecord:
+    id: int
+    user_id: int
+    filename: str
+    file_size: int
+    status: DocumentStatus
+    error_message: str | None
+    processed_at: datetime | None
+
+
+class UploadStoragePort(Protocol):
+    async def validate_and_store(self, upload_file: UploadFileLike) -> StoredUpload: ...
+
+
+class DocumentCommandPort(Protocol):
+    async def create_pending_document(
+        self,
+        *,
+        user_id: int,
+        filename: str,
+        file_path: str,
+        file_size: int,
+    ) -> DocumentRecord: ...
+
+    async def get_user_document(
+        self,
+        *,
+        document_id: int,
+        user_id: int,
+    ) -> DocumentRecord | None: ...
+
+    async def reset_failed_document_for_retry(self, *, document_id: int) -> None: ...
+
+    async def mark_upload_queue_failed(self, *, document_id: int) -> None: ...
+
+    async def mark_process_queue_failed(self, *, document_id: int) -> None: ...
+
+
+class DocumentProcessingQueuePort(Protocol):
+    async def enqueue_document_processing(self, *, document_id: int) -> bool: ...

--- a/backend/app/application/documents/use_cases.py
+++ b/backend/app/application/documents/use_cases.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.application.documents.ports import (
+    DocumentCommandPort,
+    DocumentProcessingQueuePort,
+    UploadFileLike,
+    UploadStoragePort,
+)
+from app.models.base import DocumentStatus
+
+
+class DemoUploadForbiddenError(Exception):
+    pass
+
+
+class DocumentQueueUnavailableError(Exception):
+    def __init__(self, *, document_id: int):
+        super().__init__("Document could not be queued for processing.")
+        self.document_id = document_id
+
+
+class DocumentNotFoundError(Exception):
+    pass
+
+
+class DocumentAlreadyProcessedError(Exception):
+    pass
+
+
+class DocumentAlreadyProcessingError(Exception):
+    pass
+
+
+class ProcessQueueUnavailableError(Exception):
+    def __init__(self, *, document_id: int):
+        super().__init__("Failed to queue document processing.")
+        self.document_id = document_id
+
+
+@dataclass(slots=True)
+class UploadDocumentCommand:
+    user_id: int
+    user_is_demo: bool
+    upload_file: UploadFileLike
+
+
+@dataclass(slots=True)
+class UploadDocumentResult:
+    id: int
+    user_id: int
+    filename: str
+    file_size: int
+    status: DocumentStatus
+    message: str
+
+
+class UploadDocumentUseCase:
+    def __init__(
+        self,
+        *,
+        storage: UploadStoragePort,
+        documents: DocumentCommandPort,
+        queue: DocumentProcessingQueuePort,
+    ):
+        self._storage = storage
+        self._documents = documents
+        self._queue = queue
+
+    async def execute(self, command: UploadDocumentCommand) -> UploadDocumentResult:
+        if command.user_is_demo:
+            raise DemoUploadForbiddenError
+
+        stored_upload = await self._storage.validate_and_store(command.upload_file)
+        document = await self._documents.create_pending_document(
+            user_id=command.user_id,
+            filename=stored_upload.filename,
+            file_path=stored_upload.file_path,
+            file_size=stored_upload.file_size,
+        )
+
+        try:
+            await self._queue.enqueue_document_processing(document_id=document.id)
+        except Exception as exc:
+            await self._documents.mark_upload_queue_failed(document_id=document.id)
+            raise DocumentQueueUnavailableError(document_id=document.id) from exc
+
+        return UploadDocumentResult(
+            id=document.id,
+            user_id=document.user_id,
+            filename=document.filename,
+            file_size=document.file_size,
+            status=document.status,
+            message="File uploaded successfully. Processing started in background.",
+        )
+
+
+@dataclass(slots=True)
+class ProcessDocumentCommand:
+    document_id: int
+    user_id: int
+
+
+@dataclass(slots=True)
+class ProcessDocumentResult:
+    document_id: int
+    message: str
+
+
+class ProcessDocumentUseCase:
+    def __init__(
+        self,
+        *,
+        documents: DocumentCommandPort,
+        queue: DocumentProcessingQueuePort,
+    ):
+        self._documents = documents
+        self._queue = queue
+
+    async def execute(self, command: ProcessDocumentCommand) -> ProcessDocumentResult:
+        document = await self._documents.get_user_document(
+            document_id=command.document_id,
+            user_id=command.user_id,
+        )
+        if document is None:
+            raise DocumentNotFoundError
+
+        if document.status == DocumentStatus.COMPLETED:
+            raise DocumentAlreadyProcessedError
+
+        if document.status == DocumentStatus.PROCESSING:
+            raise DocumentAlreadyProcessingError
+
+        if document.status == DocumentStatus.FAILED:
+            await self._documents.reset_failed_document_for_retry(document_id=document.id)
+
+        try:
+            enqueued = await self._queue.enqueue_document_processing(document_id=document.id)
+        except Exception as exc:
+            await self._documents.mark_process_queue_failed(document_id=document.id)
+            raise ProcessQueueUnavailableError(document_id=document.id) from exc
+
+        message = (
+            f"Document {document.id} processing already queued"
+            if not enqueued
+            else f"Document {document.id} queued for background processing"
+        )
+        return ProcessDocumentResult(
+            document_id=document.id,
+            message=message,
+        )

--- a/backend/app/infrastructure/documents/adapters.py
+++ b/backend/app/infrastructure/documents/adapters.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import cast
+
+from fastapi import UploadFile
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.application.documents.ports import (
+    DocumentRecord,
+    StoredUpload,
+    UploadFileLike,
+)
+from app.models.base import Document, DocumentStatus
+from app.utils.file_utils import save_upload_file, validate_file_upload
+
+
+class FileUtilsUploadStorageAdapter:
+    async def validate_and_store(self, upload_file: UploadFileLike) -> StoredUpload:
+        fastapi_upload = cast(UploadFile, upload_file)
+        validate_file_upload(fastapi_upload)
+        file_path, file_size = await save_upload_file(fastapi_upload)
+        filename = fastapi_upload.filename or ""
+
+        return StoredUpload(
+            filename=filename,
+            file_path=file_path,
+            file_size=file_size,
+        )
+
+
+class SQLAlchemyDocumentCommandAdapter:
+    def __init__(self, *, db: AsyncSession):
+        self._db = db
+
+    async def create_pending_document(
+        self,
+        *,
+        user_id: int,
+        filename: str,
+        file_path: str,
+        file_size: int,
+    ) -> DocumentRecord:
+        document = Document(
+            filename=filename,
+            file_path=file_path,
+            file_size=file_size,
+            status=DocumentStatus.PENDING,
+            user_id=user_id,
+        )
+        self._db.add(document)
+        await self._db.commit()
+        await self._db.refresh(document)
+        return _to_document_record(document)
+
+    async def get_user_document(
+        self,
+        *,
+        document_id: int,
+        user_id: int,
+    ) -> DocumentRecord | None:
+        document = await self._db.scalar(
+            select(Document)
+            .where(Document.id == document_id)
+            .where(Document.user_id == user_id)
+        )
+        if document is None:
+            return None
+        return _to_document_record(document)
+
+    async def reset_failed_document_for_retry(self, *, document_id: int) -> None:
+        document = await self._db.scalar(select(Document).where(Document.id == document_id))
+        if document is None:
+            return
+
+        document.status = DocumentStatus.PENDING
+        document.error_message = None
+        document.processed_at = None
+        await self._db.commit()
+
+    async def mark_upload_queue_failed(self, *, document_id: int) -> None:
+        document = await self._db.scalar(select(Document).where(Document.id == document_id))
+        if document is None:
+            return
+
+        document.status = DocumentStatus.FAILED
+        document.error_message = "Upload succeeded, but queueing failed. Please retry."
+        await self._db.commit()
+
+    async def mark_process_queue_failed(self, *, document_id: int) -> None:
+        document = await self._db.scalar(select(Document).where(Document.id == document_id))
+        if document is None:
+            return
+
+        document.status = DocumentStatus.FAILED
+        document.error_message = "Queueing failed. Please retry processing."
+        await self._db.commit()
+
+
+class QueueServiceAdapter:
+    def __init__(self, *, enqueue_document_processing_fn: Callable[[int], Awaitable[bool]]):
+        self._enqueue_document_processing_fn = enqueue_document_processing_fn
+
+    async def enqueue_document_processing(self, *, document_id: int) -> bool:
+        return await self._enqueue_document_processing_fn(document_id)
+
+
+def _to_document_record(document: Document) -> DocumentRecord:
+    return DocumentRecord(
+        id=document.id,
+        user_id=document.user_id,
+        filename=document.filename,
+        file_size=document.file_size,
+        status=document.status,
+        error_message=document.error_message,
+        processed_at=document.processed_at,
+    )

--- a/backend/tests/test_document_use_cases.py
+++ b/backend/tests/test_document_use_cases.py
@@ -1,0 +1,161 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.application.documents.ports import DocumentRecord, StoredUpload
+from app.application.documents.use_cases import (
+    DemoUploadForbiddenError,
+    DocumentAlreadyProcessedError,
+    DocumentNotFoundError,
+    DocumentQueueUnavailableError,
+    ProcessDocumentCommand,
+    ProcessDocumentUseCase,
+    ProcessQueueUnavailableError,
+    UploadDocumentCommand,
+    UploadDocumentUseCase,
+)
+from app.models.base import DocumentStatus
+
+
+class DummyUploadFile:
+    filename = "test.pdf"
+    content_type = "application/pdf"
+    size = 123
+
+    async def read(self, size: int = -1) -> bytes:
+        return b""
+
+
+def _document_record(*, status: DocumentStatus) -> DocumentRecord:
+    return DocumentRecord(
+        id=1,
+        user_id=11,
+        filename="test.pdf",
+        file_size=123,
+        status=status,
+        error_message=None,
+        processed_at=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_upload_use_case_rejects_demo_user_before_storage_call():
+    storage = AsyncMock()
+    documents = AsyncMock()
+    queue = AsyncMock()
+    use_case = UploadDocumentUseCase(storage=storage, documents=documents, queue=queue)
+
+    with pytest.raises(DemoUploadForbiddenError):
+        await use_case.execute(
+            UploadDocumentCommand(
+                user_id=11,
+                user_is_demo=True,
+                upload_file=DummyUploadFile(),
+            )
+        )
+
+    storage.validate_and_store.assert_not_awaited()
+    documents.create_pending_document.assert_not_awaited()
+    queue.enqueue_document_processing.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_upload_use_case_creates_document_and_queues_processing():
+    storage = AsyncMock()
+    documents = AsyncMock()
+    queue = AsyncMock()
+    storage.validate_and_store.return_value = StoredUpload(
+        filename="test.pdf",
+        file_path="uploads/test.pdf",
+        file_size=123,
+    )
+    documents.create_pending_document.return_value = _document_record(
+        status=DocumentStatus.PENDING
+    )
+    queue.enqueue_document_processing.return_value = True
+    use_case = UploadDocumentUseCase(storage=storage, documents=documents, queue=queue)
+
+    result = await use_case.execute(
+        UploadDocumentCommand(
+            user_id=11,
+            user_is_demo=False,
+            upload_file=DummyUploadFile(),
+        )
+    )
+
+    assert result.id == 1
+    assert result.status == DocumentStatus.PENDING
+    queue.enqueue_document_processing.assert_awaited_once_with(document_id=1)
+
+
+@pytest.mark.asyncio
+async def test_upload_use_case_marks_document_failed_when_enqueue_raises():
+    storage = AsyncMock()
+    documents = AsyncMock()
+    queue = AsyncMock()
+    storage.validate_and_store.return_value = StoredUpload(
+        filename="test.pdf",
+        file_path="uploads/test.pdf",
+        file_size=123,
+    )
+    documents.create_pending_document.return_value = _document_record(
+        status=DocumentStatus.PENDING
+    )
+    queue.enqueue_document_processing.side_effect = RuntimeError("queue unavailable")
+    use_case = UploadDocumentUseCase(storage=storage, documents=documents, queue=queue)
+
+    with pytest.raises(DocumentQueueUnavailableError):
+        await use_case.execute(
+            UploadDocumentCommand(
+                user_id=11,
+                user_is_demo=False,
+                upload_file=DummyUploadFile(),
+            )
+        )
+
+    documents.mark_upload_queue_failed.assert_awaited_once_with(document_id=1)
+
+
+@pytest.mark.asyncio
+async def test_process_use_case_raises_not_found_for_missing_document():
+    documents = AsyncMock()
+    queue = AsyncMock()
+    documents.get_user_document.return_value = None
+    use_case = ProcessDocumentUseCase(documents=documents, queue=queue)
+
+    with pytest.raises(DocumentNotFoundError):
+        await use_case.execute(ProcessDocumentCommand(document_id=10, user_id=11))
+
+    queue.enqueue_document_processing.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_use_case_raises_already_processed_error():
+    documents = AsyncMock()
+    queue = AsyncMock()
+    documents.get_user_document.return_value = _document_record(
+        status=DocumentStatus.COMPLETED
+    )
+    use_case = ProcessDocumentUseCase(documents=documents, queue=queue)
+
+    with pytest.raises(DocumentAlreadyProcessedError):
+        await use_case.execute(ProcessDocumentCommand(document_id=10, user_id=11))
+
+    queue.enqueue_document_processing.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_use_case_resets_failed_then_marks_failed_on_queue_error():
+    documents = AsyncMock()
+    queue = AsyncMock()
+    documents.get_user_document.return_value = _document_record(
+        status=DocumentStatus.FAILED
+    )
+    queue.enqueue_document_processing.side_effect = RuntimeError("queue unavailable")
+    use_case = ProcessDocumentUseCase(documents=documents, queue=queue)
+
+    with pytest.raises(ProcessQueueUnavailableError):
+        await use_case.execute(ProcessDocumentCommand(document_id=10, user_id=11))
+
+    documents.reset_failed_document_for_retry.assert_awaited_once_with(document_id=1)
+    documents.mark_process_queue_failed.assert_awaited_once_with(document_id=1)

--- a/plans/pr-task-114-mentored-ports-adapters.md
+++ b/plans/pr-task-114-mentored-ports-adapters.md
@@ -1,0 +1,50 @@
+## Summary
+
+Refactors `POST /api/documents/upload` and `POST /api/documents/{id}/process` into a ports/adapters vertical slice while preserving endpoint behavior parity.
+
+Closes #114
+
+## Why This Approach
+
+1. Chosen: thin route handlers + explicit upload/process use cases + minimal adapters.
+Alternative rejected: keep orchestration in route handlers and only extract helper functions.
+Reason: helper extraction improves file size but does not create testable architectural boundaries.
+2. Chosen: minimal ports scoped to this slice (`storage`, `document commands`, `queue`).
+Alternative rejected: broad unit-of-work/domain service framework now.
+Reason: adds abstraction cost before proving value on the first teaching slice.
+3. Chosen: preserve current HTTP contracts and queue-failure semantics exactly.
+Alternative rejected: normalize error messages/statuses during refactor.
+Reason: parity-first refactor avoids hidden behavior regressions.
+
+## Flow (Before -> After)
+
+Before:
+- Route performed validation/storage/DB writes/queue calls and HTTP mapping in one function.
+
+After:
+- Route maps HTTP request/response and domain errors only.
+- Use case orchestrates flow/state transitions.
+- Adapters wrap FastAPI upload utils, SQLAlchemy persistence, and queue enqueue service.
+
+## Changes
+
+1. Added application-layer ports and use cases for upload/process orchestration.
+2. Added infrastructure adapters for file handling, document persistence, and queue enqueue.
+3. Rewired `upload` and `process` endpoints to call use cases and map domain errors to existing HTTP responses.
+4. Added use-case tests with fake ports; kept route regression tests for status/message parity.
+
+## Verification
+
+`make backend-verify`
+
+- `ruff check .` passed
+- `mypy . --ignore-missing-imports` passed
+- `pytest -v` passed (172 tests)
+- `bandit -r app/ -ll` passed
+
+## Mentoring Checkpoints
+
+1. Checkpoint 1 (boundaries): learner paraphrases what belongs in route vs use case vs adapter.
+2. Checkpoint 2 (upload path): learner paraphrases upload success/failure transitions and retry intent.
+3. Checkpoint 3 (process path): learner paraphrases status guardrails and queue-failure behavior parity.
+4. Checkpoint 4 (review): learner paraphrases tradeoffs and when to widen this pattern beyond the slice.


### PR DESCRIPTION
## Summary

Refactors `POST /api/documents/upload` and `POST /api/documents/{id}/process` into a ports/adapters vertical slice while preserving endpoint behavior parity.

Closes #114

## Why This Approach

1. Chosen: thin route handlers + explicit upload/process use cases + minimal adapters.
Alternative rejected: keep orchestration in route handlers and only extract helper functions.
Reason: helper extraction improves file size but does not create testable architectural boundaries.
2. Chosen: minimal ports scoped to this slice (`storage`, `document commands`, `queue`).
Alternative rejected: broad unit-of-work/domain service framework now.
Reason: adds abstraction cost before proving value on the first teaching slice.
3. Chosen: preserve current HTTP contracts and queue-failure semantics exactly.
Alternative rejected: normalize error messages/statuses during refactor.
Reason: parity-first refactor avoids hidden behavior regressions.

## Flow (Before -> After)

Before:
- Route performed validation/storage/DB writes/queue calls and HTTP mapping in one function.

After:
- Route maps HTTP request/response and domain errors only.
- Use case orchestrates flow/state transitions.
- Adapters wrap FastAPI upload utils, SQLAlchemy persistence, and queue enqueue service.

## Changes

1. Added application-layer ports and use cases for upload/process orchestration.
2. Added infrastructure adapters for file handling, document persistence, and queue enqueue.
3. Rewired `upload` and `process` endpoints to call use cases and map domain errors to existing HTTP responses.
4. Added use-case tests with fake ports; kept route regression tests for status/message parity.

## Verification

`make backend-verify`

- `ruff check .` passed
- `mypy . --ignore-missing-imports` passed
- `pytest -v` passed (172 tests)
- `bandit -r app/ -ll` passed

## Mentoring Checkpoints

1. Checkpoint 1 (boundaries): learner paraphrases what belongs in route vs use case vs adapter.
2. Checkpoint 2 (upload path): learner paraphrases upload success/failure transitions and retry intent.
3. Checkpoint 3 (process path): learner paraphrases status guardrails and queue-failure behavior parity.
4. Checkpoint 4 (review): learner paraphrases tradeoffs and when to widen this pattern beyond the slice.
