### PR TITLE
Task #120: Extract non-stream query/search orchestration into service

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -16,7 +16,7 @@ from app.schemas.document import (
 from app.schemas.message import MessageListResponse, MessageResponse
 from app.schemas.query import PipelineMeta, QueryRequest, QueryResponse
 from app.schemas.search import SearchRequest, SearchResponse, SearchResult
-from app.services.anthropic_service import generate_answer, generate_answer_stream
+from app.services.anthropic_service import generate_answer_stream
 from app.services.document_commands_service import (
     delete_document_command,
     get_document_command,
@@ -26,6 +26,10 @@ from app.services.document_commands_service import (
     process_document_command,
     upload_document_command,
 )
+from app.services.document_query_service import (
+    query_document_command,
+    search_document_command,
+)
 from app.services.embedding_service import generate_embedding
 from app.services.document_service import (
     add_message,
@@ -34,7 +38,7 @@ from app.services.document_service import (
     list_user_document_messages,
     user_document_has_chunks,
 )
-from app.services.search_service import search_chunks, search_chunks_from_embedding
+from app.services.search_service import search_chunks_from_embedding
 from app.utils.logging_config import get_logger
 from app.utils.rate_limit import get_user_or_ip_key, limiter
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
@@ -316,37 +320,12 @@ async def search_document(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    await _validate_document_for_query(
+    return await search_document_command(
+        db=db,
         document_id=document_id,
         current_user=current_user,
-        db=db,
+        search=search,
     )
-
-    try:
-        results = await search_chunks(
-            query=search.query, document_id=document_id, top_k=search.top_k, db=db
-        )
-
-        search_results = [SearchResult(**result) for result in results]
-        return SearchResponse(
-            query=search.query,
-            document_id=document_id,
-            results=search_results,
-            total_results=len(results),
-        )
-
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-
-    except Exception as e:
-        logger.error(
-            "Search failed for document_id=%s, user_id=%s, error_class=%s",
-            document_id,
-            current_user.id,
-            type(e).__name__,
-            exc_info=True,
-        )
-        raise HTTPException(status_code=500, detail="Search failed")
 
 
 @router.post("/{document_id}/query", response_model=QueryResponse)
@@ -358,116 +337,14 @@ async def query_document(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """
-    Ask a question about a document and get an AI-generated answer.
-
-    Uses semantic search to find relevant chunks, then sends them to Claude
-    for natural language answer generation. Persists both user and assistant
-    messages to the database for chat history.
-    """
-
-    logger.info(
-        f"Query request for document_id={document_id}, user_id={current_user.id}, query_chars={len(body.query)}"
-    )
-
-    await _validate_document_for_query(
+    return await query_document_command(
+        db=db,
         document_id=document_id,
         current_user=current_user,
-        db=db,
+        body=body,
+        history_window_turns=CONVERSATION_HISTORY_WINDOW_TURNS,
+        similarity_threshold=SIMILARITY_THRESHOLD,
     )
-
-    try:
-        conversation_history = await _get_recent_conversation_history(
-            db=db,
-            document_id=document_id,
-            user_id=current_user.id,
-        )
-
-        user_message = await add_message(
-            db=db,
-            document_id=document_id,
-            user_id=current_user.id,
-            role="user",
-            content=body.query,
-            sources=None,
-        )
-
-        pipeline_start = time.perf_counter()
-
-        embedding_start = time.perf_counter()
-        query_embedding = await generate_embedding(body.query)
-        embed_ms = _elapsed_ms(embedding_start)
-
-        retrieval_start = time.perf_counter()
-        search_results = await _search_chunks_from_embedding(
-            db=db,
-            document_id=document_id,
-            query_embedding=query_embedding,
-            top_k=5,
-        )
-        retrieval_ms = _elapsed_ms(retrieval_start)
-
-        llm_start = time.perf_counter()
-        answer = await generate_answer(
-            query=body.query,
-            chunks=search_results,
-            conversation_history=conversation_history,
-        )
-        llm_ms = _elapsed_ms(llm_start)
-        total_ms = _elapsed_ms(pipeline_start)
-
-        # Format sources for response
-        sources = [SearchResult(**result) for result in search_results]
-        pipeline_meta = _build_pipeline_meta(
-            search_results=search_results,
-            conversation_history=conversation_history,
-            embed_ms=embed_ms,
-            retrieval_ms=retrieval_ms,
-            llm_ms=llm_ms,
-            total_ms=total_ms,
-        )
-
-        # Save assistant message to database
-        # Convert SearchResult objects to dicts for JSONB storage
-        sources_dict = [source.model_dump() for source in sources]
-        assistant_message = await add_message(
-            db=db,
-            document_id=document_id,
-            user_id=current_user.id,
-            role="assistant",
-            content=answer,
-            sources=_build_message_sources_payload(
-                sources=sources_dict,
-                pipeline_meta=pipeline_meta,
-            ),
-        )
-        await db.commit()
-
-        logger.info(
-            f"Saved messages for document_id={document_id}: user_msg_id={user_message.id}, assistant_msg_id={assistant_message.id}"
-        )
-
-        return QueryResponse(
-            query=body.query,
-            answer=answer,
-            sources=sources,
-            pipeline_meta=pipeline_meta,
-        )
-
-    except ValueError as e:
-        await db.rollback()
-        raise HTTPException(status_code=400, detail=str(e))
-
-    except Exception as e:
-        await db.rollback()
-        logger.error(
-            "Query failed for document_id=%s, user_id=%s, error_class=%s",
-            document_id,
-            current_user.id,
-            type(e).__name__,
-            exc_info=True,
-        )
-        raise HTTPException(status_code=500, detail="Query failed")
 
 
 @router.post("/{document_id}/query/stream")

--- a/backend/app/services/document_query_service.py
+++ b/backend/app/services/document_query_service.py
@@ -1,0 +1,245 @@
+import time
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.base import Document, DocumentStatus
+from app.models.user import User
+from app.schemas.query import PipelineMeta, QueryRequest, QueryResponse
+from app.schemas.search import SearchRequest, SearchResponse, SearchResult
+from app.services.anthropic_service import generate_answer
+from app.services.document_service import (
+    add_message,
+    get_recent_conversation_history,
+    get_user_document,
+    user_document_has_chunks,
+)
+from app.services.search_service import search_chunks_with_timings
+from app.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _elapsed_ms(start_time: float) -> int:
+    """Convert elapsed perf-counter seconds to integer milliseconds."""
+    return int((time.perf_counter() - start_time) * 1000)
+
+
+def _build_pipeline_meta(
+    *,
+    search_results: list[dict],
+    conversation_history: list[dict[str, str]],
+    embed_ms: int,
+    retrieval_ms: int,
+    llm_ms: int,
+    total_ms: int,
+    similarity_threshold: float,
+) -> PipelineMeta:
+    similarities = [result["similarity"] for result in search_results]
+    top_similarity = max(similarities) if similarities else 0.0
+    avg_similarity = (sum(similarities) / len(similarities)) if similarities else 0.0
+    similarity_spread = (max(similarities) - min(similarities)) if similarities else 0.0
+
+    return PipelineMeta(
+        embed_ms=embed_ms,
+        retrieval_ms=retrieval_ms,
+        llm_ms=llm_ms,
+        total_ms=total_ms,
+        top_similarity=round(top_similarity, 4),
+        avg_similarity=round(avg_similarity, 4),
+        chunks_retrieved=len(search_results),
+        chunks_above_threshold=sum(
+            1 for similarity in similarities if similarity > similarity_threshold
+        ),
+        similarity_spread=round(similarity_spread, 4),
+        chat_history_turns_included=len(conversation_history) // 2,
+    )
+
+
+def _build_message_sources_payload(
+    *,
+    sources: list[dict],
+    pipeline_meta: PipelineMeta | None,
+) -> dict:
+    payload: dict = {"sources": sources}
+    if pipeline_meta is not None:
+        payload["pipeline_meta"] = pipeline_meta.model_dump()
+    return payload
+
+
+async def _validate_document_for_query(
+    *,
+    document_id: int,
+    current_user: User,
+    db: AsyncSession,
+) -> Document:
+    """
+    Validate ownership, processing status, and chunk existence for query/search endpoints.
+    """
+    document = await get_user_document(
+        db=db,
+        document_id=document_id,
+        user_id=current_user.id,
+    )
+    if not document:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Document with ID {document_id} not found",
+        )
+
+    if document.status != DocumentStatus.COMPLETED:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Document {document_id} not processed yet",
+        )
+
+    if not await user_document_has_chunks(db=db, document_id=document_id):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Document {document_id} has no chunks",
+        )
+
+    return document
+
+
+async def search_document_command(
+    *,
+    db: AsyncSession,
+    document_id: int,
+    current_user: User,
+    search: SearchRequest,
+) -> SearchResponse:
+    await _validate_document_for_query(
+        document_id=document_id,
+        current_user=current_user,
+        db=db,
+    )
+
+    try:
+        results, _, _ = await search_chunks_with_timings(
+            query=search.query,
+            document_id=document_id,
+            top_k=search.top_k,
+            db=db,
+        )
+        search_results = [SearchResult(**result) for result in results]
+        return SearchResponse(
+            query=search.query,
+            document_id=document_id,
+            results=search_results,
+            total_results=len(results),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        logger.error(
+            "Search failed for document_id=%s, user_id=%s, error_class=%s",
+            document_id,
+            current_user.id,
+            type(exc).__name__,
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="Search failed")
+
+
+async def query_document_command(
+    *,
+    db: AsyncSession,
+    document_id: int,
+    current_user: User,
+    body: QueryRequest,
+    history_window_turns: int,
+    similarity_threshold: float,
+) -> QueryResponse:
+    logger.info(
+        f"Query request for document_id={document_id}, user_id={current_user.id}, query_chars={len(body.query)}"
+    )
+
+    await _validate_document_for_query(
+        document_id=document_id,
+        current_user=current_user,
+        db=db,
+    )
+
+    try:
+        conversation_history = await get_recent_conversation_history(
+            db=db,
+            document_id=document_id,
+            user_id=current_user.id,
+            window_turns=history_window_turns,
+        )
+
+        user_message = await add_message(
+            db=db,
+            document_id=document_id,
+            user_id=current_user.id,
+            role="user",
+            content=body.query,
+            sources=None,
+        )
+
+        pipeline_start = time.perf_counter()
+        search_results, embed_ms, retrieval_ms = await search_chunks_with_timings(
+            query=body.query,
+            document_id=document_id,
+            top_k=5,
+            db=db,
+        )
+
+        llm_start = time.perf_counter()
+        answer = await generate_answer(
+            query=body.query,
+            chunks=search_results,
+            conversation_history=conversation_history,
+        )
+        llm_ms = _elapsed_ms(llm_start)
+        total_ms = _elapsed_ms(pipeline_start)
+
+        sources = [SearchResult(**result) for result in search_results]
+        pipeline_meta = _build_pipeline_meta(
+            search_results=search_results,
+            conversation_history=conversation_history,
+            embed_ms=embed_ms,
+            retrieval_ms=retrieval_ms,
+            llm_ms=llm_ms,
+            total_ms=total_ms,
+            similarity_threshold=similarity_threshold,
+        )
+
+        sources_dict = [source.model_dump() for source in sources]
+        assistant_message = await add_message(
+            db=db,
+            document_id=document_id,
+            user_id=current_user.id,
+            role="assistant",
+            content=answer,
+            sources=_build_message_sources_payload(
+                sources=sources_dict,
+                pipeline_meta=pipeline_meta,
+            ),
+        )
+        await db.commit()
+
+        logger.info(
+            f"Saved messages for document_id={document_id}: user_msg_id={user_message.id}, assistant_msg_id={assistant_message.id}"
+        )
+
+        return QueryResponse(
+            query=body.query,
+            answer=answer,
+            sources=sources,
+            pipeline_meta=pipeline_meta,
+        )
+    except ValueError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        await db.rollback()
+        logger.error(
+            "Query failed for document_id=%s, user_id=%s, error_class=%s",
+            document_id,
+            current_user.id,
+            type(exc).__name__,
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="Query failed")

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -1,3 +1,5 @@
+import time
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.repositories.document_repository import search_document_chunks_by_embedding
@@ -42,19 +44,42 @@ async def search_chunks(query: str, document_id: int, top_k: int, db: AsyncSessi
     """
     Search for chunks semantically similar to the query.
     """
+    search_results, _, _ = await search_chunks_with_timings(
+        query=query,
+        document_id=document_id,
+        top_k=top_k,
+        db=db,
+    )
+    return search_results
+
+
+async def search_chunks_with_timings(
+    *,
+    query: str,
+    document_id: int,
+    top_k: int,
+    db: AsyncSession,
+) -> tuple[list[dict], int, int]:
+    """
+    Search for chunks semantically similar to the query and return timing metadata.
+    """
     logger.info(
         f"Searching chunks for document_id={document_id}, top_k={top_k}, query_chars={len(query)}"
     )
 
+    embed_start = time.perf_counter()
     query_embedding = await generate_embedding(query)
+    embed_ms = int((time.perf_counter() - embed_start) * 1000)
     logger.debug(f"Generated query embedding with {len(query_embedding)} dimensions")
 
+    retrieval_start = time.perf_counter()
     search_results = await search_chunks_from_embedding(
         document_id=document_id,
         query_embedding=query_embedding,
         top_k=top_k,
         db=db,
     )
+    retrieval_ms = int((time.perf_counter() - retrieval_start) * 1000)
 
     logger.info(f"Found {len(search_results)} results")
-    return search_results
+    return search_results, embed_ms, retrieval_ms

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -338,8 +338,8 @@ def mock_embeddings():
 def mock_anthropic():
     """Mock answer generation at definition + runtime call sites."""
     with patch(
-        # documents API imports generate_answer directly; patch that runtime symbol
-        "app.api.documents.generate_answer",
+        # document_query_service imports generate_answer directly; patch runtime symbol
+        "app.services.document_query_service.generate_answer",
         new_callable=AsyncMock,
         return_value="This is a test answer based on the document.",
     ) as mock_api, patch(

--- a/backend/tests/test_query.py
+++ b/backend/tests/test_query.py
@@ -154,10 +154,10 @@ class TestSearch:
     ):
         with (
             patch(
-                "app.api.documents.search_chunks",
+                "app.services.document_query_service.search_chunks_with_timings",
                 side_effect=RuntimeError("sensitive search payload"),
             ),
-            patch("app.api.documents.logger.error") as mock_error,
+            patch("app.services.document_query_service.logger.error") as mock_error,
         ):
             response = await client.post(
                 f"/api/documents/{processed_document.id}/search",
@@ -318,7 +318,7 @@ class TestQuery:
         test_user: User,
     ):
         raw_query = "sensitive compensation details"
-        with patch("app.api.documents.logger.info") as mock_info:
+        with patch("app.services.document_query_service.logger.info") as mock_info:
             response = await client.post(
                 f"/api/documents/{processed_document.id}/query",
                 headers=auth_headers,
@@ -342,10 +342,10 @@ class TestQuery:
     ):
         with (
             patch(
-                "app.api.documents.generate_embedding",
+                "app.services.document_query_service.search_chunks_with_timings",
                 side_effect=RuntimeError("sensitive query payload"),
             ),
-            patch("app.api.documents.logger.error") as mock_error,
+            patch("app.services.document_query_service.logger.error") as mock_error,
         ):
             response = await client.post(
                 f"/api/documents/{processed_document.id}/query",


### PR DESCRIPTION
## Summary
- add `document_query_service.py` to own non-stream `/search` and `/query` orchestration
- delegate non-stream route handlers in `app/api/documents.py` to the new service
- centralize non-stream embedding+retrieval timing via `search_chunks_with_timings` in `search_service`
- update query/search tests and fixtures to patch moved runtime symbols

## Verification
- `cd backend && .venv/bin/pytest -v tests/test_query.py -k "search or query and not stream"`
- `cd backend && .venv/bin/ruff check app/api/documents.py app/services/document_query_service.py app/services/search_service.py tests/test_query.py tests/conftest.py`

Closes #120
