### PR TITLE
Task #121: Extract streaming query orchestration into query service

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -1,11 +1,9 @@
 import json
-import time
 from collections.abc import AsyncGenerator
 
 from pydantic import ValidationError
 from app.api.dependencies import get_current_user
-from app.database import AsyncSessionLocal, get_db
-from app.models.base import Document, DocumentStatus
+from app.database import get_db
 from app.models.user import User
 from app.schemas.document import (
     DocumentListResponse,
@@ -15,8 +13,7 @@ from app.schemas.document import (
 )
 from app.schemas.message import MessageListResponse, MessageResponse
 from app.schemas.query import PipelineMeta, QueryRequest, QueryResponse
-from app.schemas.search import SearchRequest, SearchResponse, SearchResult
-from app.services.anthropic_service import generate_answer_stream
+from app.schemas.search import SearchRequest, SearchResponse
 from app.services.document_commands_service import (
     delete_document_command,
     get_document_command,
@@ -28,35 +25,23 @@ from app.services.document_commands_service import (
 )
 from app.services.document_query_service import (
     query_document_command,
+    query_document_stream_events_command,
     search_document_command,
 )
-from app.services.embedding_service import generate_embedding
 from app.services.document_service import (
-    add_message,
-    get_recent_conversation_history,
     get_user_document,
     list_user_document_messages,
-    user_document_has_chunks,
 )
-from app.services.search_service import search_chunks_from_embedding
-from app.utils.logging_config import get_logger
 from app.utils.rate_limit import get_user_or_ip_key, limiter
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
 from fastapi.responses import EventSourceResponse
 from fastapi.sse import ServerSentEvent, format_sse_event
 from sqlalchemy.ext.asyncio import AsyncSession
 
-logger = get_logger(__name__)
-
 router = APIRouter()
 CONVERSATION_HISTORY_WINDOW_TURNS = 5
 # Practical confidence threshold calibrated from mini-eval snapshots (2026-03-07).
 SIMILARITY_THRESHOLD = 0.60
-
-
-def _elapsed_ms(start_time: float) -> int:
-    """Convert elapsed perf-counter seconds to integer milliseconds."""
-    return int((time.perf_counter() - start_time) * 1000)
 
 
 def _encode_sse_event(event: ServerSentEvent) -> bytes:
@@ -75,47 +60,6 @@ def _encode_sse_event(event: ServerSentEvent) -> bytes:
         retry=event.retry,
         comment=event.comment,
     )
-
-
-def _build_pipeline_meta(
-    *,
-    search_results: list[dict],
-    conversation_history: list[dict[str, str]],
-    embed_ms: int,
-    retrieval_ms: int,
-    llm_ms: int,
-    total_ms: int,
-) -> PipelineMeta:
-    similarities = [result["similarity"] for result in search_results]
-    top_similarity = max(similarities) if similarities else 0.0
-    avg_similarity = (sum(similarities) / len(similarities)) if similarities else 0.0
-    similarity_spread = (max(similarities) - min(similarities)) if similarities else 0.0
-
-    return PipelineMeta(
-        embed_ms=embed_ms,
-        retrieval_ms=retrieval_ms,
-        llm_ms=llm_ms,
-        total_ms=total_ms,
-        top_similarity=round(top_similarity, 4),
-        avg_similarity=round(avg_similarity, 4),
-        chunks_retrieved=len(search_results),
-        chunks_above_threshold=sum(
-            1 for similarity in similarities if similarity > SIMILARITY_THRESHOLD
-        ),
-        similarity_spread=round(similarity_spread, 4),
-        chat_history_turns_included=len(conversation_history) // 2,
-    )
-
-
-def _build_message_sources_payload(
-    *,
-    sources: list[dict],
-    pipeline_meta: PipelineMeta | None,
-) -> dict:
-    payload: dict = {"sources": sources}
-    if pipeline_meta is not None:
-        payload["pipeline_meta"] = pipeline_meta.model_dump()
-    return payload
 
 
 def _extract_sources_and_pipeline_meta(raw_sources: object) -> tuple[list[dict] | None, PipelineMeta | None]:
@@ -138,73 +82,6 @@ def _extract_sources_and_pipeline_meta(raw_sources: object) -> tuple[list[dict] 
         pipeline_meta = None
 
     return sources, pipeline_meta
-
-
-async def _search_chunks_from_embedding(
-    *,
-    db: AsyncSession,
-    document_id: int,
-    query_embedding: list[float],
-    top_k: int,
-) -> list[dict]:
-    """
-    Search document chunks using a precomputed query embedding.
-    """
-    return await search_chunks_from_embedding(
-        db=db,
-        document_id=document_id,
-        query_embedding=query_embedding,
-        top_k=top_k,
-    )
-
-
-async def _validate_document_for_query(
-    *,
-    document_id: int,
-    current_user: User,
-    db: AsyncSession,
-) -> Document:
-    """
-    Validate ownership, processing status, and chunk existence for query/search endpoints.
-    """
-    document = await get_user_document(
-        db=db,
-        document_id=document_id,
-        user_id=current_user.id,
-    )
-    if not document:
-        raise HTTPException(
-            status_code=404, detail=f"Document with ID {document_id} not found"
-        )
-
-    if document.status != DocumentStatus.COMPLETED:
-        raise HTTPException(status_code=400, detail=f"Document {document_id} not processed yet")
-
-    if not await user_document_has_chunks(db=db, document_id=document_id):
-        raise HTTPException(status_code=400, detail=f"Document {document_id} has no chunks")
-
-    return document
-
-
-async def _get_recent_conversation_history(
-    *,
-    db: AsyncSession,
-    document_id: int,
-    user_id: int,
-    window_turns: int = CONVERSATION_HISTORY_WINDOW_TURNS,
-) -> list[dict[str, str]]:
-    """
-    Fetch the last N conversation turns for a document thread (oldest -> newest).
-
-    A turn is treated as two messages (user + assistant), so we load up to N*2
-    recent messages and reverse them to chronological order.
-    """
-    return await get_recent_conversation_history(
-        db=db,
-        document_id=document_id,
-        user_id=user_id,
-        window_turns=window_turns,
-    )
 
 
 @router.post("/upload", response_model=UploadResponse, status_code=201)
@@ -356,169 +233,17 @@ async def query_document_stream(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """
-    Stream an AI-generated answer over SSE for a document query.
-    """
-    logger.info(
-        f"Streaming query request for document_id={document_id}, user_id={current_user.id}, query_chars={len(body.query)}"
-    )
-
-    await _validate_document_for_query(
+    stream_events = await query_document_stream_events_command(
+        db=db,
         document_id=document_id,
         current_user=current_user,
-        db=db,
+        body=body,
+        history_window_turns=CONVERSATION_HISTORY_WINDOW_TURNS,
+        similarity_threshold=SIMILARITY_THRESHOLD,
     )
 
-    try:
-        conversation_history = await _get_recent_conversation_history(
-            db=db,
-            document_id=document_id,
-            user_id=current_user.id,
-        )
-
-        # Transaction 1: persist user message + run retrieval, then commit.
-        await add_message(
-            db=db,
-            document_id=document_id,
-            user_id=current_user.id,
-            role="user",
-            content=body.query,
-            sources=None,
-        )
-
-        pipeline_start = time.perf_counter()
-
-        embedding_start = time.perf_counter()
-        query_embedding = await generate_embedding(body.query)
-        embed_ms = _elapsed_ms(embedding_start)
-
-        retrieval_start = time.perf_counter()
-        search_results = await _search_chunks_from_embedding(
-            db=db,
-            document_id=document_id,
-            query_embedding=query_embedding,
-            top_k=5,
-        )
-        retrieval_ms = _elapsed_ms(retrieval_start)
-
-        sources = [SearchResult(**result) for result in search_results]
-        sources_dict = [source.model_dump() for source in sources]
-
-        await db.commit()
-    except ValueError as e:
-        await db.rollback()
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        await db.rollback()
-        logger.error(
-            "Streaming query setup failed for document_id=%s, user_id=%s, error_class=%s",
-            document_id,
-            current_user.id,
-            type(e).__name__,
-            exc_info=True,
-        )
-        raise HTTPException(status_code=500, detail="Query failed")
-
-    async def _stream_events() -> AsyncGenerator[ServerSentEvent, None]:
-        async def _persist_assistant_message(
-            *,
-            content: str,
-                sources_payload: dict | None,
-        ) -> int | None:
-            try:
-                async with AsyncSessionLocal() as write_db:
-                    assistant_message = await add_message(
-                        document_id=document_id,
-                        user_id=current_user.id,
-                        role="assistant",
-                        content=content,
-                        sources=sources_payload,
-                        db=write_db,
-                    )
-                    message_id = assistant_message.id
-                    await write_db.commit()
-                    return message_id
-            except Exception as e:
-                logger.error(
-                    "Failed to persist streamed assistant message for document_id=%s, user_id=%s, error_class=%s",
-                    document_id,
-                    current_user.id,
-                    type(e).__name__,
-                    exc_info=True,
-                )
-                return None
-
-        answer_tokens: list[str] = []
-        llm_start = time.perf_counter()
-
-        try:
-            yield ServerSentEvent(event="sources", raw_data=json.dumps(sources_dict))
-            async for token in generate_answer_stream(
-                query=body.query,
-                chunks=search_results,
-                conversation_history=conversation_history,
-            ):
-                answer_tokens.append(token)
-                yield ServerSentEvent(event="token", raw_data=token)
-        except Exception as e:
-            logger.error(
-                "Streaming query failed for document_id=%s, user_id=%s, error_class=%s",
-                document_id,
-                current_user.id,
-                type(e).__name__,
-                exc_info=True,
-            )
-            partial_answer = "".join(answer_tokens).strip()
-            assistant_content = (
-                partial_answer
-                if partial_answer
-                else "I encountered an error communicating with the AI service. Please try again later."
-            )
-            await _persist_assistant_message(
-                content=assistant_content,
-                sources_payload=_build_message_sources_payload(
-                    sources=sources_dict,
-                    pipeline_meta=None,
-                ),
-            )
-            yield ServerSentEvent(event="error", raw_data=json.dumps({"detail": "Query failed"}))
-            return
-
-        llm_ms = _elapsed_ms(llm_start)
-        pipeline_meta = _build_pipeline_meta(
-            search_results=search_results,
-            conversation_history=conversation_history,
-            embed_ms=embed_ms,
-            retrieval_ms=retrieval_ms,
-            llm_ms=llm_ms,
-            total_ms=_elapsed_ms(pipeline_start),
-        )
-        yield ServerSentEvent(event="meta", raw_data=pipeline_meta.model_dump_json())
-
-        answer = "".join(answer_tokens)
-        assistant_message_id = await _persist_assistant_message(
-            content=answer,
-            sources_payload=_build_message_sources_payload(
-                sources=sources_dict,
-                pipeline_meta=pipeline_meta,
-            ),
-        )
-        if assistant_message_id is None:
-            # Best effort fallback so chat history still has a terminal assistant turn.
-            await _persist_assistant_message(
-                content="I encountered an internal error saving the final response. Please retry.",
-                sources_payload=None,
-            )
-            yield ServerSentEvent(event="error", raw_data=json.dumps({"detail": "Query failed"}))
-            return
-
-        yield ServerSentEvent(
-            event="done",
-            raw_data=json.dumps({"message_id": assistant_message_id}),
-        )
-
     async def _encoded_stream_events() -> AsyncGenerator[bytes, None]:
-        async for event in _stream_events():
+        async for event in stream_events:
             yield _encode_sse_event(event)
 
     return EventSourceResponse(_encoded_stream_events())

--- a/backend/app/services/document_query_service.py
+++ b/backend/app/services/document_query_service.py
@@ -1,20 +1,25 @@
+import json
 import time
+from collections.abc import AsyncGenerator
 
 from fastapi import HTTPException
+from fastapi.sse import ServerSentEvent
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.database import AsyncSessionLocal
 from app.models.base import Document, DocumentStatus
 from app.models.user import User
 from app.schemas.query import PipelineMeta, QueryRequest, QueryResponse
 from app.schemas.search import SearchRequest, SearchResponse, SearchResult
-from app.services.anthropic_service import generate_answer
+from app.services.anthropic_service import generate_answer, generate_answer_stream
 from app.services.document_service import (
     add_message,
     get_recent_conversation_history,
     get_user_document,
     user_document_has_chunks,
 )
-from app.services.search_service import search_chunks_with_timings
+from app.services.embedding_service import generate_embedding
+from app.services.search_service import search_chunks_from_embedding, search_chunks_with_timings
 from app.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -243,3 +248,175 @@ async def query_document_command(
             exc_info=True,
         )
         raise HTTPException(status_code=500, detail="Query failed")
+
+
+async def query_document_stream_events_command(
+    *,
+    db: AsyncSession,
+    document_id: int,
+    current_user: User,
+    body: QueryRequest,
+    history_window_turns: int,
+    similarity_threshold: float,
+) -> AsyncGenerator[ServerSentEvent, None]:
+    logger.info(
+        f"Streaming query request for document_id={document_id}, user_id={current_user.id}, query_chars={len(body.query)}"
+    )
+
+    await _validate_document_for_query(
+        document_id=document_id,
+        current_user=current_user,
+        db=db,
+    )
+
+    try:
+        conversation_history = await get_recent_conversation_history(
+            db=db,
+            document_id=document_id,
+            user_id=current_user.id,
+            window_turns=history_window_turns,
+        )
+
+        # Transaction 1: persist user message + run retrieval, then commit.
+        await add_message(
+            db=db,
+            document_id=document_id,
+            user_id=current_user.id,
+            role="user",
+            content=body.query,
+            sources=None,
+        )
+
+        pipeline_start = time.perf_counter()
+
+        embedding_start = time.perf_counter()
+        query_embedding = await generate_embedding(body.query)
+        embed_ms = _elapsed_ms(embedding_start)
+
+        retrieval_start = time.perf_counter()
+        search_results = await search_chunks_from_embedding(
+            db=db,
+            document_id=document_id,
+            query_embedding=query_embedding,
+            top_k=5,
+        )
+        retrieval_ms = _elapsed_ms(retrieval_start)
+
+        sources = [SearchResult(**result) for result in search_results]
+        sources_dict = [source.model_dump() for source in sources]
+
+        await db.commit()
+    except ValueError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        await db.rollback()
+        logger.error(
+            "Streaming query setup failed for document_id=%s, user_id=%s, error_class=%s",
+            document_id,
+            current_user.id,
+            type(exc).__name__,
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="Query failed")
+
+    async def _persist_assistant_message(
+        *,
+        content: str,
+        sources_payload: dict | None,
+    ) -> int | None:
+        try:
+            async with AsyncSessionLocal() as write_db:
+                assistant_message = await add_message(
+                    db=write_db,
+                    document_id=document_id,
+                    user_id=current_user.id,
+                    role="assistant",
+                    content=content,
+                    sources=sources_payload,
+                )
+                message_id = assistant_message.id
+                await write_db.commit()
+                return message_id
+        except Exception as exc:
+            logger.error(
+                "Failed to persist streamed assistant message for document_id=%s, user_id=%s, error_class=%s",
+                document_id,
+                current_user.id,
+                type(exc).__name__,
+                exc_info=True,
+            )
+            return None
+
+    async def _stream_events() -> AsyncGenerator[ServerSentEvent, None]:
+        answer_tokens: list[str] = []
+        llm_start = time.perf_counter()
+
+        try:
+            yield ServerSentEvent(event="sources", raw_data=json.dumps(sources_dict))
+            async for token in generate_answer_stream(
+                query=body.query,
+                chunks=search_results,
+                conversation_history=conversation_history,
+            ):
+                answer_tokens.append(token)
+                yield ServerSentEvent(event="token", raw_data=token)
+        except Exception as exc:
+            logger.error(
+                "Streaming query failed for document_id=%s, user_id=%s, error_class=%s",
+                document_id,
+                current_user.id,
+                type(exc).__name__,
+                exc_info=True,
+            )
+            partial_answer = "".join(answer_tokens).strip()
+            assistant_content = (
+                partial_answer
+                if partial_answer
+                else "I encountered an error communicating with the AI service. Please try again later."
+            )
+            await _persist_assistant_message(
+                content=assistant_content,
+                sources_payload=_build_message_sources_payload(
+                    sources=sources_dict,
+                    pipeline_meta=None,
+                ),
+            )
+            yield ServerSentEvent(event="error", raw_data=json.dumps({"detail": "Query failed"}))
+            return
+
+        llm_ms = _elapsed_ms(llm_start)
+        pipeline_meta = _build_pipeline_meta(
+            search_results=search_results,
+            conversation_history=conversation_history,
+            embed_ms=embed_ms,
+            retrieval_ms=retrieval_ms,
+            llm_ms=llm_ms,
+            total_ms=_elapsed_ms(pipeline_start),
+            similarity_threshold=similarity_threshold,
+        )
+        yield ServerSentEvent(event="meta", raw_data=pipeline_meta.model_dump_json())
+
+        answer = "".join(answer_tokens)
+        assistant_message_id = await _persist_assistant_message(
+            content=answer,
+            sources_payload=_build_message_sources_payload(
+                sources=sources_dict,
+                pipeline_meta=pipeline_meta,
+            ),
+        )
+        if assistant_message_id is None:
+            # Best effort fallback so chat history still has a terminal assistant turn.
+            await _persist_assistant_message(
+                content="I encountered an internal error saving the final response. Please retry.",
+                sources_payload=None,
+            )
+            yield ServerSentEvent(event="error", raw_data=json.dumps({"detail": "Query failed"}))
+            return
+
+        yield ServerSentEvent(
+            event="done",
+            raw_data=json.dumps({"message_id": assistant_message_id}),
+        )
+
+    return _stream_events()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -301,9 +301,9 @@ FAKE_EMBEDDING = [0.1] * 1536
 def mock_embeddings():
     """Mock embedding functions at definition + runtime call sites."""
     with (
-        # documents API imports generate_embedding directly; patch runtime symbol
+        # document_query_service imports generate_embedding directly; patch runtime symbol
         patch(
-            "app.api.documents.generate_embedding",
+            "app.services.document_query_service.generate_embedding",
             new_callable=AsyncMock,
             return_value=FAKE_EMBEDDING,
         ) as mock_api_single,

--- a/backend/tests/test_query.py
+++ b/backend/tests/test_query.py
@@ -396,11 +396,11 @@ class TestQueryStream:
 
         with (
             patch(
-                "app.api.documents.generate_answer_stream",
+                "app.services.document_query_service.generate_answer_stream",
                 new=_fake_generate_answer_stream,
             ),
             patch(
-                "app.api.documents.AsyncSessionLocal",
+                "app.services.document_query_service.AsyncSessionLocal",
                 new=lambda: _NoCloseSessionContext(db_session),
             ),
         ):
@@ -482,13 +482,13 @@ class TestQueryStream:
             yield "streamed answer"
 
         with (
-            patch("app.api.documents.logger.info") as mock_info,
+            patch("app.services.document_query_service.logger.info") as mock_info,
             patch(
-                "app.api.documents.generate_answer_stream",
+                "app.services.document_query_service.generate_answer_stream",
                 new=_fake_generate_answer_stream,
             ),
             patch(
-                "app.api.documents.AsyncSessionLocal",
+                "app.services.document_query_service.AsyncSessionLocal",
                 new=lambda: _NoCloseSessionContext(db_session),
             ),
         ):
@@ -517,10 +517,10 @@ class TestQueryStream:
     ):
         with (
             patch(
-                "app.api.documents.generate_embedding",
+                "app.services.document_query_service.generate_embedding",
                 side_effect=RuntimeError("sensitive stream setup payload"),
             ),
-            patch("app.api.documents.logger.error") as mock_error,
+            patch("app.services.document_query_service.logger.error") as mock_error,
         ):
             response = await client.post(
                 f"/api/documents/{processed_document.id}/query/stream",
@@ -561,10 +561,10 @@ class TestQueryStream:
             raise RuntimeError("anthropic stream failed")
 
         with patch(
-            "app.api.documents.generate_answer_stream",
+            "app.services.document_query_service.generate_answer_stream",
             new=_failing_generate_answer_stream,
         ), patch(
-            "app.api.documents.AsyncSessionLocal",
+            "app.services.document_query_service.AsyncSessionLocal",
             new=lambda: _NoCloseSessionContext(db_session),
         ):
             async with client.stream(
@@ -612,14 +612,14 @@ class TestQueryStream:
 
         with (
             patch(
-                "app.api.documents.generate_answer_stream",
+                "app.services.document_query_service.generate_answer_stream",
                 new=_failing_generate_answer_stream,
             ),
             patch(
-                "app.api.documents.AsyncSessionLocal",
+                "app.services.document_query_service.AsyncSessionLocal",
                 new=lambda: _NoCloseSessionContext(db_session),
             ),
-            patch("app.api.documents.logger.error") as mock_error,
+            patch("app.services.document_query_service.logger.error") as mock_error,
         ):
             async with client.stream(
                 "POST",
@@ -678,11 +678,11 @@ class TestQueryStream:
 
         with (
             patch(
-                "app.api.documents.generate_answer_stream",
+                "app.services.document_query_service.generate_answer_stream",
                 new=_fake_generate_answer_stream,
             ),
             patch(
-                "app.api.documents.AsyncSessionLocal",
+                "app.services.document_query_service.AsyncSessionLocal",
                 new=_fail_then_succeed_session,
             ),
         ):
@@ -765,11 +765,11 @@ class TestQueryStream:
 
         with (
             patch(
-                "app.api.documents.generate_answer_stream",
+                "app.services.document_query_service.generate_answer_stream",
                 new=_fake_generate_answer_stream,
             ),
             patch(
-                "app.api.documents.AsyncSessionLocal",
+                "app.services.document_query_service.AsyncSessionLocal",
                 new=lambda: _NoCloseSessionContext(db_session),
             ),
         ):


### PR DESCRIPTION
## Summary
- move `/api/documents/{id}/query/stream` setup + SSE orchestration into `document_query_service`
- keep route thin: delegate to service and only encode/return SSE response
- preserve stream event contract/order (`sources`, `token`, `meta`, `done`, `error`) and assistant-message fallback persistence behavior
- update stream tests + shared embedding fixture patch targets for the new service-owned callsites

## Verification
- `cd backend && .venv/bin/pytest -v tests/test_query.py -k stream`

Closes #121
