### PR TITLE
Task #122: Cleanup documents readability refactor remnants

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -1,7 +1,6 @@
 import json
 from collections.abc import AsyncGenerator
 
-from pydantic import ValidationError
 from app.api.dependencies import get_current_user
 from app.database import get_db
 from app.models.user import User
@@ -11,8 +10,8 @@ from app.schemas.document import (
     DocumentStatusResponse,
     UploadResponse,
 )
-from app.schemas.message import MessageListResponse, MessageResponse
-from app.schemas.query import PipelineMeta, QueryRequest, QueryResponse
+from app.schemas.message import MessageListResponse
+from app.schemas.query import QueryRequest, QueryResponse
 from app.schemas.search import SearchRequest, SearchResponse
 from app.services.document_commands_service import (
     delete_document_command,
@@ -24,16 +23,13 @@ from app.services.document_commands_service import (
     upload_document_command,
 )
 from app.services.document_query_service import (
+    get_document_messages_command,
     query_document_command,
     query_document_stream_events_command,
     search_document_command,
 )
-from app.services.document_service import (
-    get_user_document,
-    list_user_document_messages,
-)
 from app.utils.rate_limit import get_user_or_ip_key, limiter
-from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
+from fastapi import APIRouter, Depends, File, Request, UploadFile, status
 from fastapi.responses import EventSourceResponse
 from fastapi.sse import ServerSentEvent, format_sse_event
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -60,28 +56,6 @@ def _encode_sse_event(event: ServerSentEvent) -> bytes:
         retry=event.retry,
         comment=event.comment,
     )
-
-
-def _extract_sources_and_pipeline_meta(raw_sources: object) -> tuple[list[dict] | None, PipelineMeta | None]:
-    if isinstance(raw_sources, list):
-        return raw_sources, None
-
-    if not isinstance(raw_sources, dict):
-        return None, None
-
-    sources_payload = raw_sources.get("sources")
-    sources = sources_payload if isinstance(sources_payload, list) else None
-
-    pipeline_meta_payload = raw_sources.get("pipeline_meta")
-    if not isinstance(pipeline_meta_payload, dict):
-        return sources, None
-
-    try:
-        pipeline_meta = PipelineMeta.model_validate(pipeline_meta_payload)
-    except ValidationError:
-        pipeline_meta = None
-
-    return sources, pipeline_meta
 
 
 @router.post("/upload", response_model=UploadResponse, status_code=201)
@@ -257,44 +231,8 @@ async def get_document_messages(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """
-    Get all messages for a specific document.
-
-    Returns messages in chronological order (oldest first).
-    Only returns messages for documents the user owns.
-    """
-    document = await get_user_document(
+    return await get_document_messages_command(
         db=db,
         document_id=document_id,
-        user_id=current_user.id,
-    )
-
-    if not document:
-        raise HTTPException(status_code=404, detail="Document not found")
-
-    messages = await list_user_document_messages(
-        db=db,
-        document_id=document_id,
-        user_id=current_user.id,
-    )
-
-    response_messages: list[MessageResponse] = []
-    for msg in messages:
-        sources, pipeline_meta = _extract_sources_and_pipeline_meta(msg.sources)
-        response_messages.append(
-            MessageResponse(
-                id=msg.id,
-                document_id=msg.document_id,
-                user_id=msg.user_id,
-                role=msg.role,
-                content=msg.content,
-                sources=sources,
-                pipeline_meta=pipeline_meta,
-                created_at=msg.created_at,
-            )
-        )
-
-    return MessageListResponse(
-        messages=response_messages,
-        total=len(messages),
+        current_user=current_user,
     )

--- a/backend/app/services/document_commands_service.py
+++ b/backend/app/services/document_commands_service.py
@@ -6,17 +6,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.base import Document, DocumentStatus
 from app.models.user import User
+from app.repositories.document_repository import (
+    create_document,
+    get_document_for_user,
+    list_documents_for_user,
+)
 from app.schemas.document import (
     DocumentListResponse,
     DocumentResponse,
     DocumentStatusResponse,
     UploadResponse,
-)
-from app.services.document_service import (
-    create_uploaded_document,
-    get_user_document,
-    list_user_documents,
-    remove_document,
 )
 from app.services.queue_service import enqueue_document_processing
 from app.services.storage_service import delete_file, read_file_bytes
@@ -32,7 +31,7 @@ async def _get_document_for_user_or_404(
     document_id: int,
     user_id: int,
 ) -> Document:
-    document = await get_user_document(
+    document = await get_document_for_user(
         db=db,
         document_id=document_id,
         user_id=user_id,
@@ -65,13 +64,16 @@ async def upload_document_command(
         raise HTTPException(status_code=400, detail="No filename provided")
 
     file_path, file_size = await save_upload_file(file)
-    document = await create_uploaded_document(
+    document = await create_document(
         db=db,
         filename=filename,
         file_path=file_path,
         file_size=file_size,
         user_id=current_user.id,
+        status=DocumentStatus.PENDING,
     )
+    await db.commit()
+    await db.refresh(document)
 
     try:
         await enqueue_document_processing(document.id)
@@ -107,7 +109,7 @@ async def list_documents_command(
     db: AsyncSession,
     user_id: int,
 ) -> DocumentListResponse:
-    documents = await list_user_documents(db=db, user_id=user_id)
+    documents = await list_documents_for_user(db=db, user_id=user_id)
     return DocumentListResponse(
         documents=[DocumentResponse.model_validate(d) for d in documents],
         total=len(documents),
@@ -202,7 +204,7 @@ async def delete_document_command(
     )
 
     await delete_file(document.file_path)
-    await remove_document(db=db, document=document)
+    await db.delete(document)
     await db.commit()
 
     logger.info("Successfully deleted document_id=%s", document_id)

--- a/backend/app/services/document_query_service.py
+++ b/backend/app/services/document_query_service.py
@@ -4,20 +4,22 @@ from collections.abc import AsyncGenerator
 
 from fastapi import HTTPException
 from fastapi.sse import ServerSentEvent
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import AsyncSessionLocal
 from app.models.base import Document, DocumentStatus
 from app.models.user import User
+from app.repositories.document_repository import document_has_chunks, get_document_for_user
+from app.repositories.message_repository import (
+    create_message,
+    list_messages_for_document_user,
+    list_recent_message_pairs_for_document_user,
+)
+from app.schemas.message import MessageListResponse, MessageResponse
 from app.schemas.query import PipelineMeta, QueryRequest, QueryResponse
 from app.schemas.search import SearchRequest, SearchResponse, SearchResult
 from app.services.anthropic_service import generate_answer, generate_answer_stream
-from app.services.document_service import (
-    add_message,
-    get_recent_conversation_history,
-    get_user_document,
-    user_document_has_chunks,
-)
 from app.services.embedding_service import generate_embedding
 from app.services.search_service import search_chunks_from_embedding, search_chunks_with_timings
 from app.utils.logging_config import get_logger
@@ -72,6 +74,49 @@ def _build_message_sources_payload(
     return payload
 
 
+def _extract_sources_and_pipeline_meta(
+    raw_sources: object,
+) -> tuple[list[dict] | None, PipelineMeta | None]:
+    if isinstance(raw_sources, list):
+        return raw_sources, None
+
+    if not isinstance(raw_sources, dict):
+        return None, None
+
+    sources_payload = raw_sources.get("sources")
+    sources = sources_payload if isinstance(sources_payload, list) else None
+
+    pipeline_meta_payload = raw_sources.get("pipeline_meta")
+    if not isinstance(pipeline_meta_payload, dict):
+        return sources, None
+
+    try:
+        pipeline_meta = PipelineMeta.model_validate(pipeline_meta_payload)
+    except ValidationError:
+        pipeline_meta = None
+
+    return sources, pipeline_meta
+
+
+async def _build_recent_conversation_history(
+    *,
+    db: AsyncSession,
+    document_id: int,
+    user_id: int,
+    window_turns: int,
+) -> list[dict[str, str]]:
+    if window_turns <= 0:
+        return []
+
+    rows = await list_recent_message_pairs_for_document_user(
+        db=db,
+        document_id=document_id,
+        user_id=user_id,
+        limit=window_turns * 2,
+    )
+    return [{"role": role, "content": content} for role, content in reversed(rows)]
+
+
 async def _validate_document_for_query(
     *,
     document_id: int,
@@ -81,7 +126,7 @@ async def _validate_document_for_query(
     """
     Validate ownership, processing status, and chunk existence for query/search endpoints.
     """
-    document = await get_user_document(
+    document = await get_document_for_user(
         db=db,
         document_id=document_id,
         user_id=current_user.id,
@@ -98,7 +143,7 @@ async def _validate_document_for_query(
             detail=f"Document {document_id} not processed yet",
         )
 
-    if not await user_document_has_chunks(db=db, document_id=document_id):
+    if not await document_has_chunks(db=db, document_id=document_id):
         raise HTTPException(
             status_code=400,
             detail=f"Document {document_id} has no chunks",
@@ -167,14 +212,14 @@ async def query_document_command(
     )
 
     try:
-        conversation_history = await get_recent_conversation_history(
+        conversation_history = await _build_recent_conversation_history(
             db=db,
             document_id=document_id,
             user_id=current_user.id,
             window_turns=history_window_turns,
         )
 
-        user_message = await add_message(
+        user_message = await create_message(
             db=db,
             document_id=document_id,
             user_id=current_user.id,
@@ -212,7 +257,7 @@ async def query_document_command(
         )
 
         sources_dict = [source.model_dump() for source in sources]
-        assistant_message = await add_message(
+        assistant_message = await create_message(
             db=db,
             document_id=document_id,
             user_id=current_user.id,
@@ -270,7 +315,7 @@ async def query_document_stream_events_command(
     )
 
     try:
-        conversation_history = await get_recent_conversation_history(
+        conversation_history = await _build_recent_conversation_history(
             db=db,
             document_id=document_id,
             user_id=current_user.id,
@@ -278,7 +323,7 @@ async def query_document_stream_events_command(
         )
 
         # Transaction 1: persist user message + run retrieval, then commit.
-        await add_message(
+        await create_message(
             db=db,
             document_id=document_id,
             user_id=current_user.id,
@@ -327,7 +372,7 @@ async def query_document_stream_events_command(
     ) -> int | None:
         try:
             async with AsyncSessionLocal() as write_db:
-                assistant_message = await add_message(
+                assistant_message = await create_message(
                     db=write_db,
                     document_id=document_id,
                     user_id=current_user.id,
@@ -420,3 +465,46 @@ async def query_document_stream_events_command(
         )
 
     return _stream_events()
+
+
+async def get_document_messages_command(
+    *,
+    db: AsyncSession,
+    document_id: int,
+    current_user: User,
+) -> MessageListResponse:
+    document = await get_document_for_user(
+        db=db,
+        document_id=document_id,
+        user_id=current_user.id,
+    )
+
+    if not document:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    messages = await list_messages_for_document_user(
+        db=db,
+        document_id=document_id,
+        user_id=current_user.id,
+    )
+
+    response_messages: list[MessageResponse] = []
+    for message in messages:
+        sources, pipeline_meta = _extract_sources_and_pipeline_meta(message.sources)
+        response_messages.append(
+            MessageResponse(
+                id=message.id,
+                document_id=message.document_id,
+                user_id=message.user_id,
+                role=message.role,
+                content=message.content,
+                sources=sources,
+                pipeline_meta=pipeline_meta,
+                created_at=message.created_at,
+            )
+        )
+
+    return MessageListResponse(
+        messages=response_messages,
+        total=len(messages),
+    )

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -4,19 +4,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.constants import EMBEDDING_BATCH_SIZE
 from app.models.base import Chunk, Document, DocumentStatus
-from app.models.message import Message
-from app.repositories.document_repository import (
-    create_document,
-    delete_document,
-    document_has_chunks,
-    get_document_for_user,
-    list_documents_for_user,
-)
-from app.repositories.message_repository import (
-    create_message,
-    list_messages_for_document_user,
-    list_recent_message_pairs_for_document_user,
-)
 from app.services.embedding_service import generate_embeddings_batch
 from app.services.storage_service import read_file_bytes
 from app.utils.logging_config import get_logger
@@ -26,115 +13,6 @@ from app.utils.pdf_utils import (
 )
 
 logger = get_logger(__name__)
-
-
-async def create_uploaded_document(
-    *,
-    db: AsyncSession,
-    filename: str,
-    file_path: str,
-    file_size: int,
-    user_id: int,
-) -> Document:
-    document = await create_document(
-        db=db,
-        filename=filename,
-        file_path=file_path,
-        file_size=file_size,
-        user_id=user_id,
-        status=DocumentStatus.PENDING,
-    )
-    await db.commit()
-    await db.refresh(document)
-    return document
-
-
-async def list_user_documents(
-    *,
-    db: AsyncSession,
-    user_id: int,
-) -> list[Document]:
-    return await list_documents_for_user(db=db, user_id=user_id)
-
-
-async def get_user_document(
-    *,
-    db: AsyncSession,
-    document_id: int,
-    user_id: int,
-) -> Document | None:
-    return await get_document_for_user(
-        db=db,
-        document_id=document_id,
-        user_id=user_id,
-    )
-
-
-async def get_recent_conversation_history(
-    *,
-    db: AsyncSession,
-    document_id: int,
-    user_id: int,
-    window_turns: int,
-) -> list[dict[str, str]]:
-    if window_turns <= 0:
-        return []
-
-    rows = await list_recent_message_pairs_for_document_user(
-        db=db,
-        document_id=document_id,
-        user_id=user_id,
-        limit=window_turns * 2,
-    )
-    return [{"role": role, "content": content} for role, content in reversed(rows)]
-
-
-async def list_user_document_messages(
-    *,
-    db: AsyncSession,
-    document_id: int,
-    user_id: int,
-) -> list[Message]:
-    return await list_messages_for_document_user(
-        db=db,
-        document_id=document_id,
-        user_id=user_id,
-    )
-
-
-async def add_message(
-    *,
-    db: AsyncSession,
-    document_id: int,
-    user_id: int,
-    role: str,
-    content: str,
-    sources: dict | None,
-) -> Message:
-    return await create_message(
-        db=db,
-        document_id=document_id,
-        user_id=user_id,
-        role=role,
-        content=content,
-        sources=sources,
-    )
-
-
-async def remove_document(
-    *,
-    db: AsyncSession,
-    document: Document,
-) -> None:
-    await delete_document(db=db, document=document)
-
-
-async def user_document_has_chunks(
-    *,
-    db: AsyncSession,
-    document_id: int,
-) -> bool:
-    return await document_has_chunks(db=db, document_id=document_id)
 
 
 async def process_document_text(document_id: int, db: AsyncSession) -> None:


### PR DESCRIPTION
## Summary
- remove repository pass-through wrappers from `document_service` that were no longer needed
- switch document command/query services to call repositories directly
- move document messages response shaping into `document_query_service` so API route stays thin

## Verification
- `rg -n "app\.application\.documents|app\.infrastructure\.documents" backend/app backend/tests`
- `make backend-verify`

Closes #122
