### PR TITLE
Task #123: docs guardrails for service boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,10 @@ Quaero is an AI-powered PDF question-answering platform that uses Retrieval Augm
 - **Surgical changes only.** Touch only what the task requires. Do not improve adjacent code, comments, or formatting. Match existing style.
 - **Explain what you're doing.** Include brief comments explaining why for non-obvious logic.
 - **Prefer explicit over clever.** Readable, straightforward code. No one-liners that sacrifice clarity.
+- **Respect backend boundaries.** `api -> services -> repositories`; `services -> integration services`; no cross-layer shortcuts.
+- **No pass-through-only public services.** Public service functions must add real orchestration/validation/business value; avoid wrappers that only forward arguments.
+- **Document pipeline roles stay explicit.** `document_service.py` is worker-focused; endpoint orchestration lives in document command service and document query service modules.
+- **Use a structured lightweight comment policy.** Add comments only for non-obvious invariants/transactions/contracts and keep them short; do not restate obvious code.
 
 ## Local Automation Defaults
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -528,6 +528,25 @@ async def create_room(
 
 **Services contain all business logic.** They receive a database session and validated data, perform operations, and return results or raise HTTPException.
 
+### Backend Boundary Contract
+
+Use strict layer direction for backend request flows:
+
+- `api -> services -> repositories`
+- `services -> integration services`
+- no cross-layer shortcuts (`api -> repositories`, `api -> integration services`, or repositories calling services)
+
+Service-value rule:
+
+- Do not keep pass-through-only public service functions in final state.
+- Public service APIs should own orchestration, validation, transaction boundaries, or policy decisions.
+- For the documents domain, `document_service.py` remains worker-focused while endpoint orchestration belongs in document command service / query service modules.
+
+Comment policy:
+
+- Use structured lightweight comments for non-obvious invariants, transaction boundaries, and external integration contracts.
+- Do not add comments that only narrate obvious line-by-line behavior.
+
 **Frontend (Next.js App Router):**
 
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,6 +74,29 @@ Quaero is a document intelligence platform that allows users to upload PDF docum
               generates RAG answers from retrieved chunks
 ```
 
+### Backend Boundary Model
+
+Current backend layering for document endpoints is:
+
+- `api -> services -> repositories`
+- `services -> integration services`
+- no cross-layer shortcuts
+
+Document domain role split:
+
+- `document_commands_service.py` (command service): upload/process/delete/status/file endpoint orchestration
+- `document_query_service.py` (query service): search/query/stream/messages endpoint orchestration
+- `document_service.py`: worker-focused document processing pipeline only
+
+Service-value rule:
+
+- No pass-through-only public service wrappers in final state.
+- Public service APIs should keep orchestration and policy logic close to endpoint use-cases.
+
+Comment policy:
+
+- Keep comments structured and lightweight; reserve them for invariants, transaction boundaries, and non-obvious integration behavior.
+
 ### Data Flow: Upload → Query
 
 ```

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -94,6 +94,32 @@ async def process_document_text(document_id: int, db: AsyncSession) -> None:
     # ... business logic
 ```
 
+### Backend Boundary Model
+
+Enforce explicit backend layer direction:
+
+- `api -> services -> repositories`
+- `services -> integration services` (storage, queue, embeddings, LLM)
+- no cross-layer shortcuts
+
+### Service-Value Rule
+
+Public service functions must add value (orchestration, validation, transaction ownership, policy checks).
+
+- Do not keep pass-through-only public service wrappers in final state.
+- For document flows, endpoint orchestration belongs in command service / query service modules.
+- `document_service.py` stays worker-focused for background processing.
+
+### Structured Lightweight Comment Policy
+
+Use comments sparingly and only where they add non-obvious context:
+
+- transactional boundaries and rollback intent
+- ordering/invariant guarantees
+- external API contract assumptions
+
+Do not add comments that only repeat what the next line already says.
+
 ### Background Job Queueing
 
 HTTP routes should enqueue background work via a service helper, not import ARQ pool logic directly.

--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -43,6 +43,10 @@ Post-implementation verification checklist. Run through after every feature befo
 - [ ] Consistent with patterns in PATTERNS.md
 - [ ] No dead code, commented-out code, or debug print statements
 - [ ] No `console.log` left in frontend code
+- [ ] Backend layering is preserved (`api -> services -> repositories`, `services -> integration services`) with no cross-layer shortcuts
+- [ ] Public services are not pass-through-only wrappers; they add orchestration/validation/policy value
+- [ ] Document pipeline parity holds: endpoint orchestration in command service / query service, `document_service.py` remains worker-focused
+- [ ] Comments follow the structured lightweight comment policy (non-obvious context only)
 
 ## Database
 


### PR DESCRIPTION
## Summary
- add explicit backend boundary guardrails (`api -> services -> repositories`, `services -> integration services`) in project docs
- codify no pass-through-only public service rule and document `document_service.py` as worker-focused vs command/query endpoint orchestration
- add structured lightweight comment policy and reviewer checklist parity checks

## Verification
- `rg -n "services -> repositories|cross-layer|comment" AGENTS.md WORKFLOW.md docs/PATTERNS.md docs/ARCHITECTURE.md docs/REVIEW_CHECKLIST.md`
- `rg -n "pass-through|worker-focused|command service|query service" AGENTS.md WORKFLOW.md docs/PATTERNS.md docs/ARCHITECTURE.md docs/REVIEW_CHECKLIST.md`

Closes #123
