### PR TITLE
Task #132: Extract auth command/query services and thin API layer

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,21 +1,6 @@
 from app.api.dependencies import get_current_user
-from app.core.security import (
-    create_access_token,
-    get_password_hash,
-    verify_password,
-)
 from app.database import get_db
 from app.models.user import User
-from app.repositories.refresh_token_repository import (
-    consume_refresh_token,
-    create_refresh_token,
-    delete_refresh_token,
-)
-from app.repositories.user_repository import (
-    create_user,
-    get_user_by_email,
-    get_user_by_username,
-)
 from app.schemas.user import (
     CsrfTokenResponse,
     RefreshRequest,
@@ -24,9 +9,19 @@ from app.schemas.user import (
     UserLogin,
     UserResponse,
 )
+from app.services.auth_commands_service import (
+    login_user_command,
+    logout_user_command,
+    refresh_auth_tokens_command,
+    register_user_command,
+)
+from app.services.auth_query_service import (
+    get_csrf_token_query,
+    get_refresh_token_from_request_query,
+)
 from app.utils.cookies import clear_auth_cookies, set_auth_cookies
 from app.utils.rate_limit import get_ip_key, limiter
-from fastapi import APIRouter, Body, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Body, Depends, Request, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 router = APIRouter()
@@ -41,34 +36,8 @@ async def register(
     user: UserCreate,
     db: AsyncSession = Depends(get_db),
 ):
-    """
-    Register a new user.
-
-    - Checks if username or email already exists
-    - Hashes password before storing
-    - Returns created user (without password)
-    """
-    # Check if username already exists
-    db_user = await get_user_by_username(db=db, username=user.username)
-    if db_user:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Username already registered",
-        )
-
-    # Check if email already exists
-    db_user = await get_user_by_email(db=db, email=user.email)
-    if db_user:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered"
-        )
-
-    return await create_user(
-        db=db,
-        username=user.username,
-        email=user.email,
-        hashed_password=get_password_hash(user.password),
-    )
+    del request
+    return await register_user_command(db=db, user=user)
 
 
 @router.post("/login", response_model=Token)
@@ -79,32 +48,9 @@ async def login(
     user: UserLogin,
     db: AsyncSession = Depends(get_db),
 ):
-    """
-    Login with username and password.
-
-    Sets access/refresh tokens in httpOnly cookies and returns only
-    browser-safe fields in the JSON body.
-    """
-    db_user = await get_user_by_username(db=db, username=user.username)
-    if not db_user:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect username or password",
-        )
-
-    if not verify_password(user.password, db_user.hashed_password):  # type: ignore
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect username or password",
-        )
-
-    access_token = create_access_token(data={"sub": str(db_user.id)})
-    refresh_token = await create_refresh_token(db=db, user_id=db_user.id)
-    await db.commit()
-
-    # Set httpOnly cookies; csrf_value is returned in the body for cross-domain
-    # clients that cannot read a cookie set on a different origin (see ADR-001).
-    csrf_value = set_auth_cookies(response, access_token, refresh_token)
+    del request
+    tokens = await login_user_command(db=db, user=user)
+    csrf_value = set_auth_cookies(response, tokens.access_token, tokens.refresh_token)
 
     return {"csrf_token": csrf_value, "token_type": "bearer"}
 
@@ -118,38 +64,15 @@ async def refresh(
     body: RefreshRequest | None = Body(default=None),
     db: AsyncSession = Depends(get_db),
 ):
-    """
-    Exchange a valid refresh token for a new access + refresh token pair (rotation).
-
-    Token source priority: refresh_token cookie → request body.
-    Old refresh token is deleted on use — if reused, it will 401.
-    """
-    # Cookie takes priority; body is the fallback for legacy clients
-    refresh_token_value = request.cookies.get("refresh_token") or (
-        body.refresh_token if body else None
+    refresh_token_value = get_refresh_token_from_request_query(
+        request=request,
+        body=body,
     )
-    if not refresh_token_value:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid or expired refresh token",
-        )
-
-    # Single-statement consume gate: only one request can consume a token.
-    user_id = await consume_refresh_token(db=db, token=refresh_token_value)
-    if user_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid or expired refresh token",
-        )
-
-    # Rotation: consumed old token + staged new token in one transaction.
-    new_refresh_token = await create_refresh_token(db=db, user_id=user_id)
-    await db.commit()  # single commit — both operations succeed or both roll back
-
-    access_token = create_access_token(data={"sub": str(user_id)})
-
-    # Rotate cookies; return fresh csrf_token in body for cross-domain clients.
-    csrf_value = set_auth_cookies(response, access_token, new_refresh_token)
+    tokens = await refresh_auth_tokens_command(
+        db=db,
+        refresh_token_value=refresh_token_value,
+    )
+    csrf_value = set_auth_cookies(response, tokens.access_token, tokens.refresh_token)
 
     return {"csrf_token": csrf_value, "token_type": "bearer"}
 
@@ -163,22 +86,12 @@ async def logout(
     body: RefreshRequest | None = Body(default=None),
     db: AsyncSession = Depends(get_db),
 ):
-    """
-    Invalidate a refresh token and clear auth cookies.
-
-    Token source priority: refresh_token cookie → request body.
-    Idempotent — no error if the token doesn't exist.
-    """
-    refresh_token_value = request.cookies.get("refresh_token") or (
-        body.refresh_token if body else None
+    refresh_token_value = get_refresh_token_from_request_query(
+        request=request,
+        body=body,
     )
-
-    await delete_refresh_token(db=db, token=refresh_token_value)
-    await db.commit()
-
-    # Always clear cookies regardless of token source
+    await logout_user_command(db=db, refresh_token_value=refresh_token_value)
     clear_auth_cookies(response)
-
     return {"message": "Logged out"}
 
 
@@ -197,14 +110,5 @@ async def get_csrf_token(
     request: Request,
     current_user: User = Depends(get_current_user),
 ):
-    """
-    Return the current csrf_token cookie value for authenticated sessions.
-    """
     del current_user
-    csrf_token = request.cookies.get("csrf_token")
-    if not csrf_token:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="CSRF cookie not found. Login or refresh first.",
-        )
-    return {"csrf_token": csrf_token}
+    return {"csrf_token": get_csrf_token_query(request=request)}

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -1,13 +1,13 @@
-import secrets
-
-from fastapi import Depends, Header, HTTPException, Request, status
+from fastapi import Depends, Header, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.security import decode_access_token
 from app.database import get_db
 from app.models.user import User
-from app.repositories.user_repository import get_user_by_id
+from app.services.auth_query_service import (
+    get_authenticated_user_query,
+    verify_csrf_query,
+)
 
 # auto_error=False: returns None instead of raising 401 when no Bearer header,
 # so we can check for a cookie token first before deciding to 401.
@@ -19,98 +19,15 @@ async def get_current_user(
     db: AsyncSession = Depends(get_db),
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ) -> User:
-    """Extract the authenticated user from a cookie OR a Bearer token.
-
-    Cookies are checked first (the production path after login).
-    Bearer header is the fallback — keeps Swagger UI and existing API
-    clients working without changes.
-    """
-    # Cookie path: httpOnly access_token set by login/refresh
-    cookie_token = request.cookies.get("access_token")
-    # Bearer path: Authorization: Bearer <token> header
-    bearer_token = credentials.credentials if credentials else None
-
-    token = cookie_token or bearer_token
-    if not token:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Not authenticated",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    # Decode JWT to get user_id
-    user_id_str = decode_access_token(token)
-    if user_id_str is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid authentication credentials",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    # A structurally valid JWT with a non-numeric sub should 401, not 500
-    try:
-        uid = int(user_id_str)
-    except ValueError:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid authentication credentials",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    user = await get_user_by_id(db=db, user_id=uid)
-    if user is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="User not found",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    return user
-
-
-
-# Login and register are credential-gated (require username + password); CSRF
-# is not a meaningful threat on them. Exempting them also breaks the deadlock
-# where a stale access_token cookie prevents login (see ADR-001).
-_CSRF_EXEMPT_PATHS = {"/api/auth/login", "/api/auth/register"}
+    return await get_authenticated_user_query(
+        request=request,
+        db=db,
+        credentials=credentials,
+    )
 
 
 async def verify_csrf(request: Request) -> None:
-    """Enforce double-submit CSRF protection for cookie-authenticated requests.
-
-    Rules:
-    - Safe methods (GET, HEAD, OPTIONS) are always exempt.
-    - Login and register are exempt (credential-gated, see _CSRF_EXEMPT_PATHS).
-    - If there is no access_token cookie the request is using Bearer auth,
-      which is not vulnerable to CSRF (browser won't auto-send custom headers).
-    - Otherwise: the X-CSRF-Token header must match the csrf_token cookie
-      (timing-safe comparison).
-    """
-    if request.method in {"GET", "HEAD", "OPTIONS"}:
-        return
-
-    if request.url.path in _CSRF_EXEMPT_PATHS:
-        return
-
-    # No access_token cookie → Bearer auth path → no CSRF risk
-    if not request.cookies.get("access_token"):
-        return
-
-    cookie_csrf = request.cookies.get("csrf_token")
-    header_csrf = request.headers.get("X-CSRF-Token")
-
-    if not cookie_csrf or not header_csrf:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="CSRF token missing",
-        )
-
-    # Timing-safe comparison prevents timing-oracle attacks
-    if not secrets.compare_digest(cookie_csrf, header_csrf):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="CSRF token mismatch",
-        )
+    verify_csrf_query(request=request)
 
 
 async def csrf_header_for_docs(

--- a/backend/app/services/auth_commands_service.py
+++ b/backend/app/services/auth_commands_service.py
@@ -1,0 +1,109 @@
+from typing import NamedTuple
+
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, get_password_hash, verify_password
+from app.models.user import User
+from app.repositories.refresh_token_repository import (
+    consume_refresh_token,
+    create_refresh_token,
+    delete_refresh_token,
+)
+from app.repositories.user_repository import (
+    create_user,
+    get_user_by_email,
+    get_user_by_username,
+)
+from app.schemas.user import UserCreate, UserLogin
+
+
+class AuthTokenPair(NamedTuple):
+    access_token: str
+    refresh_token: str
+
+
+async def register_user_command(
+    *,
+    db: AsyncSession,
+    user: UserCreate,
+) -> User:
+    existing_user = await get_user_by_username(db=db, username=user.username)
+    if existing_user:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Username already registered",
+        )
+
+    existing_email = await get_user_by_email(db=db, email=user.email)
+    if existing_email:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Email already registered",
+        )
+
+    return await create_user(
+        db=db,
+        username=user.username,
+        email=user.email,
+        hashed_password=get_password_hash(user.password),
+    )
+
+
+async def login_user_command(
+    *,
+    db: AsyncSession,
+    user: UserLogin,
+) -> AuthTokenPair:
+    db_user = await get_user_by_username(db=db, username=user.username)
+    if not db_user or not verify_password(user.password, db_user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+        )
+
+    access_token = create_access_token(data={"sub": str(db_user.id)})
+    refresh_token = await create_refresh_token(db=db, user_id=db_user.id)
+    await db.commit()
+
+    return AuthTokenPair(
+        access_token=access_token,
+        refresh_token=refresh_token,
+    )
+
+
+async def refresh_auth_tokens_command(
+    *,
+    db: AsyncSession,
+    refresh_token_value: str | None,
+) -> AuthTokenPair:
+    if not refresh_token_value:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+        )
+
+    user_id = await consume_refresh_token(db=db, token=refresh_token_value)
+    if user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired refresh token",
+        )
+
+    new_refresh_token = await create_refresh_token(db=db, user_id=user_id)
+    await db.commit()
+    access_token = create_access_token(data={"sub": str(user_id)})
+
+    return AuthTokenPair(
+        access_token=access_token,
+        refresh_token=new_refresh_token,
+    )
+
+
+async def logout_user_command(
+    *,
+    db: AsyncSession,
+    refresh_token_value: str | None,
+) -> None:
+    await delete_refresh_token(db=db, token=refresh_token_value)
+    await db.commit()

--- a/backend/app/services/auth_query_service.py
+++ b/backend/app/services/auth_query_service.py
@@ -1,0 +1,102 @@
+import secrets
+
+from fastapi import HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import decode_access_token
+from app.models.user import User
+from app.repositories.user_repository import get_user_by_id
+from app.schemas.user import RefreshRequest
+
+# Login/register are credential-gated and don't need CSRF protection.
+_CSRF_EXEMPT_PATHS = {"/api/auth/login", "/api/auth/register"}
+
+
+async def get_authenticated_user_query(
+    *,
+    request: Request,
+    db: AsyncSession,
+    credentials: HTTPAuthorizationCredentials | None,
+) -> User:
+    cookie_token = request.cookies.get("access_token")
+    bearer_token = credentials.credentials if credentials else None
+
+    token = cookie_token or bearer_token
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    user_id_str = decode_access_token(token)
+    if user_id_str is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    try:
+        user_id = int(user_id_str)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    user = await get_user_by_id(db=db, user_id=user_id)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return user
+
+
+def get_refresh_token_from_request_query(
+    *,
+    request: Request,
+    body: RefreshRequest | None,
+) -> str | None:
+    return request.cookies.get("refresh_token") or (body.refresh_token if body else None)
+
+
+def get_csrf_token_query(*, request: Request) -> str:
+    csrf_token = request.cookies.get("csrf_token")
+    if not csrf_token:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="CSRF cookie not found. Login or refresh first.",
+        )
+    return csrf_token
+
+
+def verify_csrf_query(*, request: Request) -> None:
+    if request.method in {"GET", "HEAD", "OPTIONS"}:
+        return
+
+    if request.url.path in _CSRF_EXEMPT_PATHS:
+        return
+
+    if not request.cookies.get("access_token"):
+        return
+
+    cookie_csrf = request.cookies.get("csrf_token")
+    header_csrf = request.headers.get("X-CSRF-Token")
+
+    if not cookie_csrf or not header_csrf:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="CSRF token missing",
+        )
+
+    if not secrets.compare_digest(cookie_csrf, header_csrf):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="CSRF token mismatch",
+        )

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -482,7 +482,10 @@ class TestRefresh:
             del db, user_id
             raise RuntimeError("forced refresh rotation failure")
 
-        monkeypatch.setattr("app.api.auth.create_refresh_token", _raise_during_rotation)
+        monkeypatch.setattr(
+            "app.services.auth_commands_service.create_refresh_token",
+            _raise_during_rotation,
+        )
 
         with pytest.raises(RuntimeError):
             await client.post(


### PR DESCRIPTION
## Summary
- add `auth_commands_service` for register/login/refresh/logout orchestration
- add `auth_query_service` for current-user lookup, refresh-token source resolution, CSRF checks, and CSRF cookie lookup
- thin `api/auth.py` and `api/dependencies.py` to HTTP/DI delegation with no direct DB transaction operations
- update auth test monkeypatch target for refresh-rotation failure injection

## Verification
- `cd backend && .venv/bin/pytest -v tests/test_auth.py tests/test_rate_limit.py`
- `rg -n "from app\\.crud" backend/app/api`
- `rg -n "db\\.(commit|rollback|execute|scalar|scalars|refresh|flush)" backend/app/api/auth.py backend/app/api/dependencies.py`

## Issue
Closes #132
