### PR TITLE
Task #133: Worker processing repository extraction

### DIFF
--- a/backend/app/repositories/document_repository.py
+++ b/backend/app/repositories/document_repository.py
@@ -1,4 +1,4 @@
-from sqlalchemy import literal, select
+from sqlalchemy import delete, literal, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.base import Chunk, Document, DocumentStatus
@@ -67,6 +67,37 @@ async def delete_document(
     document: Document,
 ) -> None:
     await db.delete(document)
+
+
+async def delete_chunks_for_document(
+    *,
+    db: AsyncSession,
+    document_id: int,
+) -> None:
+    stmt = delete(Chunk).where(Chunk.document_id == document_id)
+    await db.execute(stmt)
+
+
+async def create_chunks_for_document(
+    *,
+    db: AsyncSession,
+    document_id: int,
+    chunk_payloads: list[tuple[str, int | None, int | None]],
+) -> list[Chunk]:
+    chunks: list[Chunk] = []
+    for chunk_index, (content, page_start, page_end) in enumerate(chunk_payloads):
+        chunk = Chunk(
+            document_id=document_id,
+            content=content,
+            chunk_index=chunk_index,
+            page_start=page_start,
+            page_end=page_end,
+        )
+        db.add(chunk)
+        chunks.append(chunk)
+
+    await db.flush()
+    return chunks
 
 
 async def document_has_chunks(

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -1,9 +1,14 @@
 # backend/app/services/document_service.py
-from sqlalchemy import delete, func, select
+from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.constants import EMBEDDING_BATCH_SIZE
-from app.models.base import Chunk, Document, DocumentStatus
+from app.models.base import DocumentStatus
+from app.repositories.document_repository import (
+    create_chunks_for_document,
+    delete_chunks_for_document,
+    get_document_by_id,
+)
 from app.services.embedding_service import generate_embeddings_batch
 from app.services.storage_service import read_file_bytes
 from app.utils.logging_config import get_logger
@@ -31,8 +36,7 @@ async def process_document_text(document_id: int, db: AsyncSession) -> None:
     logger.info(f"Starting document processing: document_id={document_id}")
 
     # Get document
-    stmt = select(Document).where(Document.id == document_id)
-    document = await db.scalar(stmt)
+    document = await get_document_by_id(db=db, document_id=document_id)
 
     if not document:
         logger.error(f"Document not found: document_id={document_id}")
@@ -51,7 +55,7 @@ async def process_document_text(document_id: int, db: AsyncSession) -> None:
         document.processed_at = None
 
         # Retry semantics: always rebuild from scratch to avoid duplicate chunks.
-        await db.execute(delete(Chunk).where(Chunk.document_id == document.id))
+        await delete_chunks_for_document(db=db, document_id=document.id)
         await db.commit()
 
         # Extract text from pdf (CPU-bound, offloaded to process pool)
@@ -71,21 +75,14 @@ async def process_document_text(document_id: int, db: AsyncSession) -> None:
         )
         logger.info(f"Created {len(chunks)} chunks")
 
-        # Build chunks and add to db, chunk_objects list preserves order for embeddings
-        chunk_objects = []
-        for i, chunk_payload in enumerate(chunks):
-            chunk = Chunk(
-                document_id=document.id,
-                content=chunk_payload.content,
-                chunk_index=i,
-                page_start=chunk_payload.page_start,
-                page_end=chunk_payload.page_end,
-            )
-            chunk_objects.append(chunk)
-            db.add(chunk)
-
-        # Flush to get chunk IDs without committing
-        await db.flush()
+        chunk_payloads = [
+            (chunk.content, chunk.page_start, chunk.page_end) for chunk in chunks
+        ]
+        chunk_objects = await create_chunks_for_document(
+            db=db,
+            document_id=document.id,
+            chunk_payloads=chunk_payloads,
+        )
 
         # Generate embeddings in bounded batches to keep memory stable for large docs.
         logger.info(f"Generating embeddings for {len(chunks)} chunks")
@@ -121,9 +118,7 @@ async def process_document_text(document_id: int, db: AsyncSession) -> None:
         # Explicitly clear the current unit of work so flushed chunk rows are not committed.
         await db.rollback()
 
-        failed_document = await db.scalar(
-            select(Document).where(Document.id == document_id)
-        )
+        failed_document = await get_document_by_id(db=db, document_id=document_id)
         if failed_document:
             failed_document.status = DocumentStatus.FAILED
             failed_document.error_message = str(e)

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -40,19 +40,6 @@ async def search_chunks_from_embedding(
     return search_results
 
 
-async def search_chunks(query: str, document_id: int, top_k: int, db: AsyncSession) -> list[dict]:
-    """
-    Search for chunks semantically similar to the query.
-    """
-    search_results, _, _ = await search_chunks_with_timings(
-        query=query,
-        document_id=document_id,
-        top_k=top_k,
-        db=db,
-    )
-    return search_results
-
-
 async def search_chunks_with_timings(
     *,
     query: str,


### PR DESCRIPTION
## Summary
- move document worker DB primitives into `document_repository` (`get_document_by_id`, chunk delete/create helpers) while keeping transaction ownership in `document_service`
- keep `document_service.py` worker-focused on pipeline orchestration, status transitions, and failure handling
- remove unused pass-through `search_chunks()` wrapper from `search_service.py`

## Verification
- `cd backend && .venv/bin/pytest -v tests/test_document_service.py tests/test_document_tasks.py tests/test_query.py`
- `rg -n "select\\(|delete\\(|db\\.(scalar|execute)" backend/app/services/document_service.py`
- `rg -n "async def search_chunks\\(" backend/app/services/search_service.py`

## Issue
Closes #133
