### PR TITLE
Task #139: Extract demo-seed persistence into repository layer

### DIFF
--- a/backend/app/repositories/demo_seed_repository.py
+++ b/backend/app/repositories/demo_seed_repository.py
@@ -1,0 +1,104 @@
+from datetime import datetime
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.base import Chunk, Document, DocumentStatus
+from app.models.user import User
+
+
+async def get_user_by_username_or_email(
+    *,
+    db: AsyncSession,
+    username: str,
+    email: str,
+) -> User | None:
+    stmt = select(User).where(or_(User.username == username, User.email == email))
+    return await db.scalar(stmt)
+
+
+async def create_demo_user(
+    *,
+    db: AsyncSession,
+    username: str,
+    email: str,
+    hashed_password: str,
+) -> User:
+    demo_user = User(
+        username=username,
+        email=email,
+        hashed_password=hashed_password,
+        is_demo=True,
+    )
+    db.add(demo_user)
+    await db.flush()
+    return demo_user
+
+
+async def list_documents_with_chunks_for_user(
+    *,
+    db: AsyncSession,
+    user_id: int,
+) -> list[Document]:
+    stmt = (
+        select(Document)
+        .where(Document.user_id == user_id)
+        .options(selectinload(Document.chunks))
+    )
+    return list((await db.scalars(stmt)).all())
+
+
+async def delete_documents(
+    *,
+    db: AsyncSession,
+    documents: list[Document],
+) -> None:
+    for document in documents:
+        await db.delete(document)
+    await db.flush()
+
+
+async def create_completed_document(
+    *,
+    db: AsyncSession,
+    user_id: int,
+    filename: str,
+    file_path: str,
+    file_size: int,
+    processed_at: datetime,
+) -> Document:
+    document = Document(
+        filename=filename,
+        file_path=file_path,
+        file_size=file_size,
+        status=DocumentStatus.COMPLETED,
+        user_id=user_id,
+        processed_at=processed_at,
+        error_message=None,
+    )
+    db.add(document)
+    await db.flush()
+    return document
+
+
+async def create_document_chunk(
+    *,
+    db: AsyncSession,
+    document_id: int,
+    content: str,
+    chunk_index: int,
+    page_start: int | None,
+    page_end: int | None,
+    embedding: list[float],
+) -> None:
+    db.add(
+        Chunk(
+            document_id=document_id,
+            content=content,
+            chunk_index=chunk_index,
+            page_start=page_start,
+            page_end=page_end,
+            embedding=embedding,
+        )
+    )

--- a/backend/app/services/demo_seed_service.py
+++ b/backend/app/services/demo_seed_service.py
@@ -8,14 +8,20 @@ from pathlib import Path
 from typing import Any
 
 from app.core.security import get_password_hash
-from app.models.base import Chunk, Document, DocumentStatus
+from app.models.base import Document
 from app.models.user import User
+from app.repositories.demo_seed_repository import (
+    create_completed_document,
+    create_demo_user,
+    create_document_chunk,
+    delete_documents,
+    get_user_by_username_or_email,
+    list_documents_with_chunks_for_user,
+)
 from app.services.storage_service import read_file_bytes, write_file_bytes
 from app.utils.logging_config import get_logger
-from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 logger = get_logger(__name__)
 
@@ -198,17 +204,14 @@ async def _seed_documents(
         )
         fixture_file_size = _coerce_int(doc_payload.get("file_size"), default=0)
 
-        document = Document(
+        document = await create_completed_document(
+            db=db,
+            user_id=demo_user_id,
             filename=filename,
             file_path=file_path,
             file_size=fixture_file_size if fixture_file_size > 0 else resolved_file_size,
-            status=DocumentStatus.COMPLETED,
-            user_id=demo_user_id,
             processed_at=datetime.utcnow(),
-            error_message=None,
         )
-        db.add(document)
-        await db.flush()
 
         chunks_payload = doc_payload.get("chunks", [])
         if not isinstance(chunks_payload, list):
@@ -225,15 +228,14 @@ async def _seed_documents(
                 else []
             )
 
-            db.add(
-                Chunk(
-                    document_id=document.id,
-                    content=str(chunk_payload.get("content", "")),
-                    chunk_index=_coerce_int(chunk_payload.get("chunk_index"), default=0),
-                    page_start=_coerce_optional_int(chunk_payload.get("page_start")),
-                    page_end=_coerce_optional_int(chunk_payload.get("page_end")),
-                    embedding=embedding,
-                )
+            await create_document_chunk(
+                db=db,
+                document_id=document.id,
+                content=str(chunk_payload.get("content", "")),
+                chunk_index=_coerce_int(chunk_payload.get("chunk_index"), default=0),
+                page_start=_coerce_optional_int(chunk_payload.get("page_start")),
+                page_end=_coerce_optional_int(chunk_payload.get("page_end")),
+                embedding=embedding,
             )
 
 
@@ -243,12 +245,9 @@ async def _reconcile_documents_for_existing_demo_user(
     demo_user: User,
     documents_payload: list[dict[str, Any]],
 ) -> int:
-    existing_documents = list(
-        await db.scalars(
-            select(Document)
-            .where(Document.user_id == demo_user.id)
-            .options(selectinload(Document.chunks))
-        )
+    existing_documents = await list_documents_with_chunks_for_user(
+        db=db,
+        user_id=demo_user.id,
     )
     fixture_filenames = _fixture_filename_set(documents_payload)
     existing_filenames = {document.filename for document in existing_documents}
@@ -259,9 +258,7 @@ async def _reconcile_documents_for_existing_demo_user(
         logger.info("Demo seed no-op: fixture signature unchanged")
         return len(existing_documents)
 
-    for document in existing_documents:
-        await db.delete(document)
-    await db.flush()
+    await delete_documents(db=db, documents=existing_documents)
 
     await _seed_documents(db, demo_user_id=demo_user.id, documents_payload=documents_payload)
     logger.info(
@@ -274,10 +271,10 @@ async def _reconcile_documents_for_existing_demo_user(
 
 async def seed_demo_user(db: AsyncSession) -> None:
     """Seed or reconcile demo user documents from fixture data on startup."""
-    existing_demo = await db.scalar(
-        select(User).where(
-            or_(User.username == DEMO_USERNAME, User.email == DEMO_EMAIL)
-        )
+    existing_demo = await get_user_by_username_or_email(
+        db=db,
+        username=DEMO_USERNAME,
+        email=DEMO_EMAIL,
     )
 
     try:
@@ -291,14 +288,12 @@ async def seed_demo_user(db: AsyncSession) -> None:
 
         if existing_demo is None:
             try:
-                demo_user = User(
+                demo_user = await create_demo_user(
+                    db=db,
                     username=DEMO_USERNAME,
                     email=DEMO_EMAIL,
                     hashed_password=get_password_hash(DEMO_PASSWORD),
-                    is_demo=True,
                 )
-                db.add(demo_user)
-                await db.flush()
             except IntegrityError:
                 await db.rollback()
                 logger.info("Demo seed skipped due to concurrent unique-key conflict")


### PR DESCRIPTION
## Summary
- extract demo-seed persistence/query primitives into `app/repositories/demo_seed_repository.py`
- keep `demo_seed_service.py` focused on fixture parsing, reconciliation decisions, and transaction boundaries
- preserve demo seeding and reconciliation behavior while removing direct SQLAlchemy query/persistence primitives from service layer

## Verification
- `cd backend && .venv/bin/pytest -v tests/test_demo_seed.py`
- `cd backend && rg -n "select\\(|db\\.(scalar|scalars|execute|flush|delete)" app/services/demo_seed_service.py` (no matches)

Closes #139
Related to #134
