### PR TITLE
Task #145: Extract transport boundary and keep api facade compatibility

### DIFF
--- a/frontend/lib/__tests__/api.auth.test.ts
+++ b/frontend/lib/__tests__/api.auth.test.ts
@@ -8,6 +8,14 @@ function jsonResponse(status: number, body: unknown): Response {
   });
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe("apiRequest auth refresh contract", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -77,5 +85,63 @@ describe("apiRequest auth refresh contract", () => {
     expect(localStorage.getItem("csrf_token")).toBeNull();
     expect(localStorage.getItem("access_token")).toBeNull();
     expect(localStorage.getItem("refresh_token")).toBeNull();
+  });
+
+  it("uses a single refresh request for concurrent 401 responses", async () => {
+    localStorage.setItem("csrf_token", "csrf-old");
+    const refreshResult = deferred<Response>();
+    let documentRequestCount = 0;
+
+    const fetchMock = vi.fn((input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = String(input);
+
+      if (url === "http://localhost:8000/api/documents/") {
+        documentRequestCount += 1;
+        if (documentRequestCount <= 2) {
+          return Promise.resolve(jsonResponse(401, { detail: "Unauthorized" }));
+        }
+        return Promise.resolve(jsonResponse(200, { documents: [], total: 0 }));
+      }
+
+      if (url === "http://localhost:8000/api/auth/refresh") {
+        return refreshResult.promise;
+      }
+
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const firstRequest = api.getDocuments();
+    const secondRequest = api.getDocuments();
+
+    await Promise.resolve();
+    refreshResult.resolve(jsonResponse(200, { csrf_token: "csrf-new", token_type: "bearer" }));
+
+    await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual([
+      { documents: [], total: 0 },
+      { documents: [], total: 0 },
+    ]);
+
+    const refreshCalls = fetchMock.mock.calls.filter(
+      ([url]) => String(url) === "http://localhost:8000/api/auth/refresh"
+    );
+    const retriedDocumentCalls = fetchMock.mock.calls.filter(
+      ([url]) => String(url) === "http://localhost:8000/api/documents/"
+    ).slice(2);
+
+    expect(refreshCalls).toHaveLength(1);
+    expect(retriedDocumentCalls).toHaveLength(2);
+    expect(retriedDocumentCalls[0]?.[1]).toMatchObject({
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": "csrf-new",
+      },
+    });
+    expect(retriedDocumentCalls[1]?.[1]).toMatchObject({
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": "csrf-new",
+      },
+    });
   });
 });

--- a/frontend/lib/__tests__/api.contract.test.ts
+++ b/frontend/lib/__tests__/api.contract.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import * as apiModule from "@/lib/api";
+
+describe("public api module contract", () => {
+  it("exposes stable helpers and error types", () => {
+    expect(typeof apiModule.isLoggedIn).toBe("function");
+    expect(typeof apiModule.saveTokens).toBe("function");
+    expect(typeof apiModule.loginAsDemo).toBe("function");
+    expect(apiModule.ApiError).toBeDefined();
+    expect(apiModule.SessionExpiredError).toBeDefined();
+  });
+
+  it("exposes stable api method surface", () => {
+    expect(Object.keys(apiModule.api).sort()).toEqual([
+      "deleteDocument",
+      "getCurrentUser",
+      "getDocumentFile",
+      "getDocumentStatus",
+      "getDocuments",
+      "getMessages",
+      "login",
+      "logout",
+      "processDocument",
+      "queryDocument",
+      "queryDocumentStream",
+      "register",
+      "uploadDocument",
+    ]);
+  });
+});

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -17,9 +17,14 @@ import type {
   MessageListResponse,
   PipelineMeta,
 } from "./api.types";
-import { ApiError, SessionExpiredError } from "./api.types";
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+import { ApiError } from "./api.types";
+import { fullUrl } from "./api/config";
+import {
+  clearAuthTokens,
+  getCsrfToken,
+  requestWithAuthRefresh,
+  saveAuthTokens,
+} from "./api/http";
 
 // Re-export so components can do: import { api, Document, ApiError } from "@/lib/api"
 export { ApiError } from "./api.types";
@@ -51,17 +56,6 @@ interface QueryStreamOptions {
 // ---------------------------------------------------------------------------
 
 /**
- * Read the CSRF token stored in localStorage after login/refresh.
- * The token arrives in the JSON response body because the backend sets it as a
- * cookie on its own domain — which document.cookie on Vercel cannot read (see
- * ADR-001). Safe to call during SSR (returns null when window is not available).
- */
-function getCsrfToken(): string | null {
-  if (typeof window === "undefined") return null;
-  return localStorage.getItem("csrf_token");
-}
-
-/**
  * Instant auth check based on the CSRF token in localStorage.
  * Use for UI routing decisions (redirect to /login or /dashboard).
  * Not a security guarantee — actual auth is enforced by the backend
@@ -78,7 +72,7 @@ export function isLoggedIn(): boolean {
  * set by the backend automatically — only the CSRF token needs JS storage.
  */
 export function saveTokens(tokens: AuthResponse): void {
-  localStorage.setItem("csrf_token", tokens.csrf_token);
+  saveAuthTokens(tokens);
 }
 
 const DEMO_CREDENTIALS: LoginCredentials = {
@@ -95,64 +89,6 @@ export async function loginAsDemo(): Promise<void> {
   saveTokens(response);
 }
 
-/**
- * Clear the CSRF token from localStorage on logout or session expiry.
- * Also removes legacy auth keys left over from before the cookie migration.
- * Does NOT touch cookies — only the backend can clear those via Max-Age=0.
- */
-function clearTokens(): void {
-  localStorage.removeItem("csrf_token");
-  localStorage.removeItem("access_token");  // legacy cleanup
-  localStorage.removeItem("refresh_token"); // legacy cleanup
-}
-
-/** Builds full URL from a path; only place that prepends API_URL. */
-function fullUrl(path: string): string {
-  return `${API_URL}${path}`;
-}
-
-// ---------------------------------------------------------------------------
-// Silent token refresh with single-flight lock
-// ---------------------------------------------------------------------------
-
-// Module-level promise so concurrent 401s share one refresh attempt
-let refreshPromise: Promise<boolean> | null = null;
-
-async function refreshAccessToken(): Promise<boolean> {
-  if (refreshPromise) return refreshPromise;
-
-  refreshPromise = doRefresh();
-  try {
-    return await refreshPromise;
-  } finally {
-    refreshPromise = null;
-  }
-}
-
-/**
- * Ask the backend to rotate the refresh token.
- * No request body — the httpOnly refresh_token cookie is the credential.
- * The backend responds with Set-Cookie headers and a JSON body that includes
- * a fresh csrf_token. We save it so subsequent requests use the new value.
- * Uses raw fetch (not apiRequest) to avoid a 401 refresh cycle.
- */
-async function doRefresh(): Promise<boolean> {
-  const csrf = getCsrfToken();
-  const response = await fetch(fullUrl("/api/auth/refresh"), {
-    method: "POST",
-    credentials: "include",
-    headers: {
-      "Content-Type": "application/json",
-      ...(csrf ? { "X-CSRF-Token": csrf } : {}),
-    },
-  });
-  if (response.ok) {
-    const data: AuthResponse = await response.json();
-    saveTokens(data); // persist rotated CSRF token
-  }
-  return response.ok;
-}
-
 // ---------------------------------------------------------------------------
 // Core request helper
 // ---------------------------------------------------------------------------
@@ -165,44 +101,16 @@ async function doRefresh(): Promise<boolean> {
  * a typed session error for the UI boundary to handle.
  */
 async function apiRequest(path: string, options: RequestInit = {}) {
-  const csrf = getCsrfToken();
   const isFormData = options.body instanceof FormData;
 
-  const headers: HeadersInit = {
-    ...(isFormData ? {} : { "Content-Type": "application/json" }),
-    // Include CSRF token when we have it; backend skips check on GET/safe methods
-    ...(csrf ? { "X-CSRF-Token": csrf } : {}),
-    ...options.headers,
-  };
-
-  let response = await fetch(fullUrl(path), {
+  const response = await requestWithAuthRefresh(path, (csrfToken) => ({
     ...options,
-    headers,
-    credentials: "include", // send httpOnly cookies cross-origin
-  });
-
-  // On 401, attempt one silent refresh then retry
-  if (response.status === 401) {
-    const refreshed = await refreshAccessToken();
-    if (refreshed) {
-      // Re-read CSRF token — the refresh response set a new one
-      const newCsrf = getCsrfToken();
-      const retryHeaders: HeadersInit = {
-        ...(isFormData ? {} : { "Content-Type": "application/json" }),
-        ...(newCsrf ? { "X-CSRF-Token": newCsrf } : {}),
-        ...options.headers,
-      };
-      response = await fetch(fullUrl(path), {
-        ...options,
-        headers: retryHeaders,
-        credentials: "include",
-      });
-    } else {
-      // Refresh failed — session is dead; clear any stale localStorage values
-      clearTokens();
-      throw new SessionExpiredError();
-    }
-  }
+    headers: {
+      ...(isFormData ? {} : { "Content-Type": "application/json" }),
+      ...(csrfToken ? { "X-CSRF-Token": csrfToken } : {}),
+      ...options.headers,
+    },
+  }));
 
   if (!response.ok) {
     const error = await response
@@ -256,7 +164,7 @@ export const api = {
       },
       // No body — the refresh_token httpOnly cookie is the credential
     }).catch(() => {}); // backend may be unreachable — local clear still happens
-    clearTokens();
+    clearAuthTokens();
   },
 
   /** Get the currently logged-in user (requires auth). */
@@ -295,29 +203,15 @@ export const api = {
 
   /** Download a document PDF for in-app viewing. */
   getDocumentFile: async (documentId: number): Promise<Blob> => {
-    const buildHeaders = (csrfToken: string | null): HeadersInit => ({
-      ...(csrfToken ? { "X-CSRF-Token": csrfToken } : {}),
-    });
-
-    let response = await fetch(fullUrl(`/api/documents/${documentId}/file`), {
-      method: "GET",
-      credentials: "include",
-      headers: buildHeaders(getCsrfToken()),
-    });
-
-    if (response.status === 401) {
-      const refreshed = await refreshAccessToken();
-      if (refreshed) {
-        response = await fetch(fullUrl(`/api/documents/${documentId}/file`), {
-          method: "GET",
-          credentials: "include",
-          headers: buildHeaders(getCsrfToken()),
-        });
-      } else {
-        clearTokens();
-        throw new SessionExpiredError();
-      }
-    }
+    const response = await requestWithAuthRefresh(
+      `/api/documents/${documentId}/file`,
+      (csrfToken) => ({
+        method: "GET",
+        headers: {
+          ...(csrfToken ? { "X-CSRF-Token": csrfToken } : {}),
+        },
+      })
+    );
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ detail: "Failed to load document" }));
@@ -355,35 +249,18 @@ export const api = {
     callbacks: QueryStreamCallbacks,
     options: QueryStreamOptions = {}
   ): Promise<void> => {
-    const buildHeaders = (csrfToken: string | null): HeadersInit => ({
-      "Content-Type": "application/json",
-      ...(csrfToken ? { "X-CSRF-Token": csrfToken } : {}),
-    });
-
-    let response = await fetch(fullUrl(`/api/documents/${documentId}/query/stream`), {
-      method: "POST",
-      credentials: "include",
-      headers: buildHeaders(getCsrfToken()),
-      body: JSON.stringify({ query }),
-      signal: options.signal,
-    });
-
-    // On 401, attempt one silent refresh then retry
-    if (response.status === 401) {
-      const refreshed = await refreshAccessToken();
-      if (refreshed) {
-        response = await fetch(fullUrl(`/api/documents/${documentId}/query/stream`), {
-          method: "POST",
-          credentials: "include",
-          headers: buildHeaders(getCsrfToken()),
-          body: JSON.stringify({ query }),
-          signal: options.signal,
-        });
-      } else {
-        clearTokens();
-        throw new SessionExpiredError();
-      }
-    }
+    const response = await requestWithAuthRefresh(
+      `/api/documents/${documentId}/query/stream`,
+      (csrfToken) => ({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(csrfToken ? { "X-CSRF-Token": csrfToken } : {}),
+        },
+        body: JSON.stringify({ query }),
+        signal: options.signal,
+      })
+    );
 
     if (!response.ok) {
       const error = await response

--- a/frontend/lib/api/config.ts
+++ b/frontend/lib/api/config.ts
@@ -1,0 +1,6 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+/** Builds full URL from a backend path. */
+export function fullUrl(path: string): string {
+  return `${API_URL}${path}`;
+}

--- a/frontend/lib/api/http.ts
+++ b/frontend/lib/api/http.ts
@@ -1,0 +1,87 @@
+import type { AuthResponse } from "../api.types";
+import { SessionExpiredError } from "../api.types";
+import { fullUrl } from "./config";
+
+/**
+ * Read the CSRF token stored in localStorage after login/refresh.
+ * Safe to call during SSR (returns null when window is not available).
+ */
+export function getCsrfToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem("csrf_token");
+}
+
+/** Persist the CSRF token from an auth response into localStorage. */
+export function saveAuthTokens(tokens: AuthResponse): void {
+  localStorage.setItem("csrf_token", tokens.csrf_token);
+}
+
+/** Clear client-side auth hints from localStorage. */
+export function clearAuthTokens(): void {
+  localStorage.removeItem("csrf_token");
+  localStorage.removeItem("access_token");  // legacy cleanup
+  localStorage.removeItem("refresh_token"); // legacy cleanup
+}
+
+// Module-level promise so concurrent 401s share one refresh attempt.
+let refreshPromise: Promise<boolean> | null = null;
+
+async function doRefresh(): Promise<boolean> {
+  const csrf = getCsrfToken();
+  const response = await fetch(fullUrl("/api/auth/refresh"), {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      ...(csrf ? { "X-CSRF-Token": csrf } : {}),
+    },
+  });
+
+  if (response.ok) {
+    const data: AuthResponse = await response.json();
+    saveAuthTokens(data);
+  }
+
+  return response.ok;
+}
+
+async function refreshAccessToken(): Promise<boolean> {
+  if (refreshPromise) return refreshPromise;
+
+  refreshPromise = doRefresh();
+  try {
+    return await refreshPromise;
+  } finally {
+    refreshPromise = null;
+  }
+}
+
+/**
+ * Sends an authenticated request with one silent refresh retry on 401.
+ * The request factory is called before the first request and again after
+ * refresh so callers automatically pick up the rotated CSRF token.
+ */
+export async function requestWithAuthRefresh(
+  path: string,
+  buildRequest: (csrfToken: string | null) => RequestInit
+): Promise<Response> {
+  let response = await fetch(fullUrl(path), {
+    ...buildRequest(getCsrfToken()),
+    credentials: "include",
+  });
+
+  if (response.status === 401) {
+    const refreshed = await refreshAccessToken();
+    if (!refreshed) {
+      clearAuthTokens();
+      throw new SessionExpiredError();
+    }
+
+    response = await fetch(fullUrl(path), {
+      ...buildRequest(getCsrfToken()),
+      credentials: "include",
+    });
+  }
+
+  return response;
+}


### PR DESCRIPTION
## Summary
- extract API base URL config into `frontend/lib/api/config.ts`
- extract CSRF helpers, single-flight refresh, and shared auth-refresh request flow into `frontend/lib/api/http.ts`
- keep `frontend/lib/api.ts` API-compatible while delegating transport behavior to the new modules
- route blob and streaming calls through shared transport refresh logic
- add regression coverage for concurrent 401 single-flight refresh and add public API surface contract test

## Verification
- `cd frontend && npm test -- lib/__tests__/api.auth.test.ts lib/__tests__/api.queryDocumentStream.test.ts lib/__tests__/api.contract.test.ts && npx tsc --noEmit`

Closes #145
