### PR TITLE
Task #146: frontend boundary alignment

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -4,342 +4,56 @@
  */
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useCallback } from "react";
 import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { PanelLeft, X, FileUp } from "lucide-react";
-import { api, isLoggedIn, type Document, ApiError, SessionExpiredError } from "@/lib/api";
 import { UploadZone } from "../components/dashboard/UploadZone";
 import { DocumentList } from "../components/dashboard/DocumentList";
 import { ChatWindow } from "../components/dashboard/ChatWindow";
 import { DeleteDocumentModal } from "../components/dashboard/DeleteDocumentModal";
+import { useDashboardState } from "@/lib/hooks/useDashboardState";
 
 const SIDEBAR_WIDTH = "w-72";
-const SPLIT_LAYOUT_MIN_WIDTH = 1120;
-const SPLIT_LAYOUT_RESTORE_WIDTH = 1240;
-const getInitialUseTabLayout = (): boolean => {
-  if (typeof window === "undefined") return true;
-  return window.innerWidth < SPLIT_LAYOUT_MIN_WIDTH;
-};
 const PdfViewer = dynamic(
   () => import("../components/dashboard/PdfViewer").then((mod) => mod.PdfViewer),
   { ssr: false }
 );
 
-interface CitationTarget {
-  page: number;
-  snippet?: string;
-}
-
 export default function DashboardPage() {
-  const [documents, setDocuments] = useState<Document[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
-  const [selectedDocument, setSelectedDocument] = useState<Document | null>(null);
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [documentToDelete, setDocumentToDelete] = useState<Document | null>(null);
-  const [deletingInProgress, setDeletingInProgress] = useState(false);
-  const [highlightPage, setHighlightPage] = useState<number | null>(null);
-  const [highlightSnippet, setHighlightSnippet] = useState<string | null>(null);
-  const [mobileTab, setMobileTab] = useState<"pdf" | "chat">("chat");
-  const [useTabLayout, setUseTabLayout] = useState(getInitialUseTabLayout);
-  const [desktopSidebarCollapsed, setDesktopSidebarCollapsed] = useState(false);
-  const [workspaceElement, setWorkspaceElement] = useState<HTMLDivElement | null>(null);
-  const [isDemoUser, setIsDemoUser] = useState(false);
-  const documentsRef = useRef<Document[]>([]);
-  const workspaceRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
-  const hasActiveDocuments = documents.some(
-    (doc) => doc.status === "pending" || doc.status === "processing"
-  );
   const handleSessionExpired = useCallback(() => {
     router.push("/login");
   }, [router]);
-
-  const isSessionExpired = useCallback((err: unknown): boolean => {
-    return err instanceof SessionExpiredError || (err instanceof ApiError && err.status === 401);
-  }, []);
-
-  const handleApiError = useCallback(
-    (err: unknown, fallbackMessage: string): boolean => {
-      if (isSessionExpired(err)) {
-        handleSessionExpired();
-        return true;
-      }
-
-      if (err instanceof ApiError) {
-        setError(err.detail);
-      } else {
-        setError(fallbackMessage);
-      }
-      return false;
-    },
-    [handleSessionExpired, isSessionExpired]
-  );
-
-  const loadDocuments = useCallback(async () => {
-    try {
-      const response = await api.getDocuments();
-      setDocuments(response.documents);
-    } catch (err) {
-      handleApiError(err, "Failed to load documents");
-    }
-  }, [handleApiError]);
-
-  useEffect(() => {
-    if (!isLoggedIn()) return handleSessionExpired();
-    let cancelled = false;
-
-    const loadInitialData = async () => {
-      try {
-        const [userResponse, documentsResponse] = await Promise.all([
-          api.getCurrentUser(),
-          api.getDocuments(),
-        ]);
-        if (cancelled) return;
-        setIsDemoUser(userResponse.is_demo);
-        setDocuments(documentsResponse.documents);
-      } catch (err) {
-        if (!cancelled) {
-          handleApiError(err, "Failed to load documents");
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    };
-
-    void loadInitialData();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [handleSessionExpired, handleApiError]);
-
-  useEffect(() => {
-    documentsRef.current = documents;
-  }, [documents]);
-
-  useEffect(() => {
-    if (!selectedDocument) return;
-    const updatedDocument = documents.find((doc) => doc.id === selectedDocument.id);
-
-    if (!updatedDocument) {
-      setSelectedDocument(null);
-      return;
-    }
-
-    if (updatedDocument !== selectedDocument) {
-      setSelectedDocument(updatedDocument);
-    }
-  }, [documents, selectedDocument]);
-
-  useEffect(() => {
-    if (loading || !hasActiveDocuments) return;
-
-    let cancelled = false;
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    let delayMs = 3000;
-
-    const scheduleNextPoll = () => {
-      if (cancelled) return;
-      timeoutId = setTimeout(pollStatuses, delayMs);
-    };
-
-    const pollStatuses = async () => {
-      const activeDocuments = documentsRef.current.filter(
-        (doc) => doc.status === "pending" || doc.status === "processing"
-      );
-
-      if (activeDocuments.length === 0 || cancelled) return;
-
-      const targetIds = activeDocuments.map((doc) => doc.id);
-      const results = await Promise.allSettled(
-        targetIds.map((id) => api.getDocumentStatus(id))
-      );
-
-      if (cancelled) return;
-
-      let shouldRedirectToLogin = false;
-      let hadPollFailures = false;
-      const missingIds = new Set<number>();
-      const statusById = new Map<number, Awaited<ReturnType<typeof api.getDocumentStatus>>>();
-
-      results.forEach((result, index) => {
-        const documentId = targetIds[index];
-        if (result.status === "fulfilled") {
-          statusById.set(documentId, result.value);
-          return;
-        }
-
-        const reason = result.reason;
-        if (isSessionExpired(reason)) {
-          shouldRedirectToLogin = true;
-          return;
-        }
-
-        if (reason instanceof ApiError && reason.status === 404) {
-          missingIds.add(documentId);
-          return;
-        }
-
-        hadPollFailures = true;
-      });
-
-      if (shouldRedirectToLogin) {
-        handleSessionExpired();
-        return;
-      }
-
-      if (statusById.size > 0 || missingIds.size > 0) {
-        setDocuments((prev) =>
-          prev
-            .filter((doc) => !missingIds.has(doc.id))
-            .map((doc) => {
-              const status = statusById.get(doc.id);
-              if (!status) return doc;
-              return {
-                ...doc,
-                status: status.status,
-                processed_at: status.processed_at,
-                error_message: status.error_message,
-              };
-            })
-        );
-      }
-
-      if (hadPollFailures && statusById.size === 0) {
-        delayMs = Math.min(delayMs * 2, 10000);
-      } else {
-        delayMs = Math.min(Math.floor(delayMs * 1.5), 10000);
-      }
-
-      scheduleNextPoll();
-    };
-
-    scheduleNextPoll();
-
-    return () => {
-      cancelled = true;
-      if (timeoutId) clearTimeout(timeoutId);
-    };
-  }, [hasActiveDocuments, loading, handleSessionExpired, isSessionExpired]);
-
-  useEffect(() => {
-    if (!workspaceElement) return;
-
-    let frameId: number | null = null;
-
-    const updateLayoutMode = (width: number) => {
-      setUseTabLayout((current) => {
-        if (current) {
-          return width < SPLIT_LAYOUT_RESTORE_WIDTH;
-        }
-        return width < SPLIT_LAYOUT_MIN_WIDTH;
-      });
-    };
-
-    updateLayoutMode(Math.floor(workspaceElement.clientWidth));
-
-    const observer = new ResizeObserver((entries) => {
-      const [entry] = entries;
-      if (!entry) return;
-
-      if (frameId !== null) window.cancelAnimationFrame(frameId);
-      frameId = window.requestAnimationFrame(() => {
-        updateLayoutMode(Math.floor(entry.contentRect.width));
-      });
-    });
-
-    observer.observe(workspaceElement);
-
-    return () => {
-      if (frameId !== null) window.cancelAnimationFrame(frameId);
-      observer.disconnect();
-    };
-  }, [workspaceElement]);
-
-  const handleUpload = async (file: File) => {
-    setError("");
-    try {
-      await api.uploadDocument(file);
-      await loadDocuments();
-    } catch (err) {
-      handleApiError(err, "Upload failed");
-    }
-  };
-
-  const handleLogout = async () => {
-    await api.logout();
-    handleSessionExpired();
-  };
-
-  const handleDocumentClick = (document: Document) => {
-    if (document.status !== "completed") return;
-    setSelectedDocument(document);
-    setHighlightPage(null);
-    setHighlightSnippet(null);
-    setMobileTab("chat");
-    setSidebarOpen(false);
-  };
-
-  const handleBackToDocuments = () => {
-    setSelectedDocument(null);
-    setHighlightPage(null);
-    setHighlightSnippet(null);
-    setSidebarOpen(true);
-  };
-
-  const handleCitationClick = ({ page, snippet }: CitationTarget) => {
-    const nextSnippet = snippet?.trim() || null;
-    setMobileTab("pdf");
-    setHighlightSnippet(nextSnippet);
-    setHighlightPage((current) => {
-      if (current === page) {
-        setHighlightSnippet(null);
-        window.setTimeout(() => {
-          setHighlightSnippet(nextSnippet);
-          setHighlightPage(page);
-        }, 0);
-        return null;
-      }
-      return page;
-    });
-  };
-
-  const handleProcessDocument = async (doc: Document) => {
-    setError("");
-    try {
-      await api.processDocument(doc.id);
-      await loadDocuments();
-    } catch (err) {
-      handleApiError(err, "Failed to queue processing");
-    }
-  };
-
-  const handleDeleteDocument = (doc: Document) => {
-    setDocumentToDelete(doc);
-  };
-
-  const handleConfirmDelete = async () => {
-    if (!documentToDelete) return;
-    const doc = documentToDelete;
-    setDeletingInProgress(true);
-    setError("");
-    try {
-      await api.deleteDocument(doc.id);
-      setDocumentToDelete(null);
-      if (selectedDocument?.id === doc.id) setSelectedDocument(null);
-      await loadDocuments();
-    } catch (err) {
-      if (err instanceof ApiError && err.status === 403) {
-        setDocumentToDelete(null);
-      }
-      handleApiError(err, "Failed to delete document");
-    } finally {
-      setDeletingInProgress(false);
-    }
-  };
+  const {
+    documents,
+    loading,
+    error,
+    selectedDocument,
+    sidebarOpen,
+    documentToDelete,
+    deletingInProgress,
+    highlightPage,
+    highlightSnippet,
+    mobileTab,
+    useTabLayout,
+    desktopSidebarCollapsed,
+    isDemoUser,
+    handleUpload,
+    handleLogout,
+    handleDocumentClick,
+    handleBackToDocuments,
+    handleCitationClick,
+    handleProcessDocument,
+    handleDeleteDocument,
+    handleConfirmDelete,
+    handleCancelDelete,
+    setSidebarOpen,
+    setWorkspaceElement,
+    setMobileTab,
+    setDesktopSidebarCollapsed,
+  } = useDashboardState({ onSessionExpired: handleSessionExpired });
 
   const showPdfPane = !useTabLayout || mobileTab === "pdf";
   const showChatPane = !useTabLayout || mobileTab === "chat";
@@ -453,7 +167,7 @@ export default function DashboardPage() {
             document={documentToDelete}
             deleting={deletingInProgress}
             onConfirm={handleConfirmDelete}
-            onCancel={() => setDocumentToDelete(null)}
+            onCancel={handleCancelDelete}
           />
         )}
 

--- a/frontend/lib/hooks/__tests__/useDashboardState.test.tsx
+++ b/frontend/lib/hooks/__tests__/useDashboardState.test.tsx
@@ -1,0 +1,155 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Document } from "@/lib/api";
+import type { User } from "@/lib/api.types";
+import * as api from "@/lib/api";
+import { SessionExpiredError } from "@/lib/api";
+import { useDashboardState } from "@/lib/hooks/useDashboardState";
+import { documentService } from "@/lib/services/documentService";
+
+const onSessionExpiredMock = vi.fn();
+const isLoggedInMock = vi.spyOn(api, "isLoggedIn");
+
+function makeDocument(overrides: Partial<Document> = {}): Document {
+  return {
+    id: 101,
+    user_id: 1,
+    filename: "alpha.pdf",
+    file_size: 2048,
+    status: "completed",
+    uploaded_at: "2026-03-01T10:00:00Z",
+    processed_at: "2026-03-01T10:01:00Z",
+    error_message: null,
+    ...overrides,
+  };
+}
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 1,
+    username: "alice",
+    email: "alice@example.com",
+    is_demo: false,
+    created_at: "2026-03-01T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function setupHookHarness() {
+  const stateRef: { current: ReturnType<typeof useDashboardState> | null } = {
+    current: null,
+  };
+
+  const HookHarness = () => {
+    const state = useDashboardState({ onSessionExpired: onSessionExpiredMock });
+    stateRef.current = state;
+    return null;
+  };
+
+  render(<HookHarness />);
+  return { stateRef };
+}
+
+describe("useDashboardState", () => {
+  const getDashboardContextMock = vi.spyOn(documentService, "getDashboardContext");
+  const getDocumentsMock = vi.spyOn(documentService, "getDocuments");
+  const uploadDocumentMock = vi.spyOn(documentService, "uploadDocument");
+  const getDocumentStatusMock = vi.spyOn(documentService, "getDocumentStatus");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onSessionExpiredMock.mockReset();
+    isLoggedInMock.mockReturnValue(true);
+    getDashboardContextMock.mockResolvedValue({
+      user: makeUser(),
+      documents: [],
+    });
+    getDocumentsMock.mockResolvedValue({ documents: [], total: 0 });
+    uploadDocumentMock.mockResolvedValue(makeDocument());
+    getDocumentStatusMock.mockResolvedValue({
+      id: 101,
+      status: "processing",
+      processed_at: null,
+      error_message: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("loads dashboard context into state and clears loading", async () => {
+    const doc = makeDocument({ id: 1, filename: "guide.pdf" });
+    getDashboardContextMock.mockResolvedValueOnce({
+      user: makeUser(),
+      documents: [doc],
+    });
+
+    const { stateRef } = setupHookHarness();
+
+    await waitFor(() => {
+      expect(stateRef.current?.loading).toBe(false);
+    });
+
+    expect(stateRef.current?.documents).toEqual([doc]);
+    expect(stateRef.current?.isDemoUser).toBe(false);
+  });
+
+  it(
+    "redirects on polling session-expired errors",
+    async () => {
+    const pending = makeDocument({
+      id: 201,
+      status: "processing",
+    });
+    getDashboardContextMock.mockResolvedValueOnce({
+      user: makeUser(),
+      documents: [pending],
+    });
+    getDocumentStatusMock.mockRejectedValueOnce(new SessionExpiredError());
+
+    const { stateRef } = setupHookHarness();
+
+    await waitFor(() => {
+      expect(stateRef.current?.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 3200));
+    });
+
+      await waitFor(() => {
+        expect(onSessionExpiredMock).toHaveBeenCalledTimes(1);
+      });
+      expect(stateRef.current?.documents).toEqual([pending]);
+    },
+    9000
+  );
+
+  it("reloads documents after upload", async () => {
+    const doc = makeDocument({ id: 301 });
+    const refreshed = makeDocument({ id: 302, filename: "new.pdf" });
+    getDashboardContextMock.mockResolvedValueOnce({
+      user: makeUser(),
+      documents: [doc],
+    });
+    getDocumentsMock.mockResolvedValue({ documents: [doc, refreshed], total: 2 });
+
+    const { stateRef } = setupHookHarness();
+    await waitFor(() => {
+      expect(stateRef.current?.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await stateRef.current?.handleUpload(
+        new File(["%PDF"], "upload.pdf", { type: "application/pdf" })
+      );
+    });
+
+    await waitFor(() => {
+      expect(uploadDocumentMock).toHaveBeenCalledTimes(1);
+      expect(getDocumentsMock).toHaveBeenCalledTimes(1);
+      expect(stateRef.current?.documents).toEqual([doc, refreshed]);
+    });
+  });
+});

--- a/frontend/lib/hooks/useDashboardState.ts
+++ b/frontend/lib/hooks/useDashboardState.ts
@@ -1,0 +1,404 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ApiError,
+  isLoggedIn,
+  type Document,
+  SessionExpiredError,
+} from "@/lib/api";
+import { documentService } from "@/lib/services/documentService";
+
+const SPLIT_LAYOUT_MIN_WIDTH = 1120;
+const SPLIT_LAYOUT_RESTORE_WIDTH = 1240;
+const POLL_INITIAL_DELAY_MS = 3000;
+const POLL_MAX_DELAY_MS = 10000;
+
+const getInitialUseTabLayout = (): boolean => {
+  if (typeof window === "undefined") return true;
+  return window.innerWidth < SPLIT_LAYOUT_MIN_WIDTH;
+};
+
+export type MobileTab = "pdf" | "chat";
+
+interface CitationTarget {
+  page: number;
+  snippet?: string;
+}
+
+interface UseDashboardStateOptions {
+  onSessionExpired: () => void;
+}
+
+export interface UseDashboardStateResult {
+  documents: Document[];
+  loading: boolean;
+  error: string;
+  selectedDocument: Document | null;
+  sidebarOpen: boolean;
+  documentToDelete: Document | null;
+  deletingInProgress: boolean;
+  highlightPage: number | null;
+  highlightSnippet: string | null;
+  mobileTab: MobileTab;
+  useTabLayout: boolean;
+  desktopSidebarCollapsed: boolean;
+  workspaceElement: HTMLDivElement | null;
+  isDemoUser: boolean;
+  hasActiveDocuments: boolean;
+  handleUpload: (file: File) => Promise<void>;
+  handleLogout: () => Promise<void>;
+  handleDocumentClick: (document: Document) => void;
+  handleBackToDocuments: () => void;
+  handleCitationClick: (citation: CitationTarget) => void;
+  handleProcessDocument: (doc: Document) => Promise<void>;
+  handleDeleteDocument: (doc: Document) => void;
+  handleConfirmDelete: () => Promise<void>;
+  handleCancelDelete: () => void;
+  setSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setWorkspaceElement: React.Dispatch<React.SetStateAction<HTMLDivElement | null>>;
+  setMobileTab: React.Dispatch<React.SetStateAction<MobileTab>>;
+  setDesktopSidebarCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export function useDashboardState({
+  onSessionExpired,
+}: UseDashboardStateOptions): UseDashboardStateResult {
+  const [documents, setDocuments] = useState<Document[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [selectedDocument, setSelectedDocument] = useState<Document | null>(null);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [documentToDelete, setDocumentToDelete] = useState<Document | null>(null);
+  const [deletingInProgress, setDeletingInProgress] = useState(false);
+  const [highlightPage, setHighlightPage] = useState<number | null>(null);
+  const [highlightSnippet, setHighlightSnippet] = useState<string | null>(null);
+  const [mobileTab, setMobileTab] = useState<MobileTab>("chat");
+  const [useTabLayout, setUseTabLayout] = useState(getInitialUseTabLayout);
+  const [desktopSidebarCollapsed, setDesktopSidebarCollapsed] = useState(false);
+  const [workspaceElement, setWorkspaceElement] = useState<HTMLDivElement | null>(null);
+  const [isDemoUser, setIsDemoUser] = useState(false);
+  const documentsRef = useRef<Document[]>([]);
+
+  const isSessionExpired = useCallback((err: unknown): boolean => {
+    return err instanceof SessionExpiredError || (err instanceof ApiError && err.status === 401);
+  }, []);
+
+  const handleSessionExpired = useCallback(() => {
+    onSessionExpired();
+  }, [onSessionExpired]);
+
+  const handleApiError = useCallback(
+    (err: unknown, fallbackMessage: string): boolean => {
+      if (isSessionExpired(err)) {
+        handleSessionExpired();
+        return true;
+      }
+
+      if (err instanceof ApiError) {
+        setError(err.detail);
+      } else {
+        setError(fallbackMessage);
+      }
+      return false;
+    },
+    [handleSessionExpired, isSessionExpired]
+  );
+
+  const loadDocuments = useCallback(async () => {
+    try {
+      const response = await documentService.getDocuments();
+      setDocuments(response.documents);
+    } catch (err) {
+      handleApiError(err, "Failed to load documents");
+    }
+  }, [handleApiError]);
+
+  useEffect(() => {
+    if (!isLoggedIn()) return handleSessionExpired();
+    let cancelled = false;
+
+    const loadInitialData = async () => {
+      try {
+        const dashboardContext = await documentService.getDashboardContext();
+        if (cancelled) return;
+        setIsDemoUser(dashboardContext.user.is_demo);
+        setDocuments(dashboardContext.documents);
+      } catch (err) {
+        if (!cancelled) {
+          handleApiError(err, "Failed to load documents");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void loadInitialData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [handleApiError, handleSessionExpired]);
+
+  useEffect(() => {
+    documentsRef.current = documents;
+  }, [documents]);
+
+  useEffect(() => {
+    if (!selectedDocument) return;
+
+    const updatedDocument = documents.find((doc) => doc.id === selectedDocument.id);
+    if (!updatedDocument) {
+      setSelectedDocument(null);
+      return;
+    }
+
+    if (updatedDocument !== selectedDocument) {
+      setSelectedDocument(updatedDocument);
+    }
+  }, [documents, selectedDocument]);
+
+  const hasActiveDocuments = documents.some(
+    (doc) => doc.status === "pending" || doc.status === "processing"
+  );
+
+  useEffect(() => {
+    if (loading || !hasActiveDocuments) return;
+
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let delayMs = POLL_INITIAL_DELAY_MS;
+
+    const scheduleNextPoll = () => {
+      if (cancelled) return;
+      timeoutId = setTimeout(pollStatuses, delayMs);
+    };
+
+    const pollStatuses = async () => {
+      const activeDocuments = documentsRef.current.filter(
+        (doc) => doc.status === "pending" || doc.status === "processing"
+      );
+
+      if (activeDocuments.length === 0 || cancelled) return;
+
+      const targetIds = activeDocuments.map((doc) => doc.id);
+      const results = await Promise.allSettled(
+        targetIds.map((id) => documentService.getDocumentStatus(id))
+      );
+
+      if (cancelled) return;
+
+      let shouldRedirectToLogin = false;
+      let hadPollFailures = false;
+      const missingIds = new Set<number>();
+      const statusById = new Map<number, Awaited<ReturnType<typeof documentService.getDocumentStatus>>>();
+
+      results.forEach((result, index) => {
+        const documentId = targetIds[index];
+        if (result.status === "fulfilled") {
+          statusById.set(documentId, result.value);
+          return;
+        }
+
+        const reason = result.reason;
+        if (isSessionExpired(reason)) {
+          shouldRedirectToLogin = true;
+          return;
+        }
+
+        if (reason instanceof ApiError && reason.status === 404) {
+          missingIds.add(documentId);
+          return;
+        }
+
+        hadPollFailures = true;
+      });
+
+      if (shouldRedirectToLogin) {
+        handleSessionExpired();
+        return;
+      }
+
+      if (statusById.size > 0 || missingIds.size > 0) {
+        setDocuments((prev) =>
+          prev
+            .filter((doc) => !missingIds.has(doc.id))
+            .map((doc) => {
+              const status = statusById.get(doc.id);
+              if (!status) return doc;
+              return {
+                ...doc,
+                status: status.status,
+                processed_at: status.processed_at,
+                error_message: status.error_message,
+              };
+            })
+        );
+      }
+
+      if (hadPollFailures && statusById.size === 0) {
+        delayMs = Math.min(delayMs * 2, POLL_MAX_DELAY_MS);
+      } else {
+        delayMs = Math.min(Math.floor(delayMs * 1.5), POLL_MAX_DELAY_MS);
+      }
+
+      scheduleNextPoll();
+    };
+
+    scheduleNextPoll();
+
+    return () => {
+      cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [hasActiveDocuments, loading, handleSessionExpired, isSessionExpired]);
+
+  useEffect(() => {
+    if (!workspaceElement) return;
+
+    let frameId: number | null = null;
+
+    const updateLayoutMode = (width: number) => {
+      setUseTabLayout((current) => {
+        if (current) {
+          return width < SPLIT_LAYOUT_RESTORE_WIDTH;
+        }
+        return width < SPLIT_LAYOUT_MIN_WIDTH;
+      });
+    };
+
+    updateLayoutMode(Math.floor(workspaceElement.clientWidth));
+
+    const observer = new ResizeObserver((entries) => {
+      const [entry] = entries;
+      if (!entry) return;
+
+      if (frameId !== null) window.cancelAnimationFrame(frameId);
+      frameId = window.requestAnimationFrame(() => {
+        updateLayoutMode(Math.floor(entry.contentRect.width));
+      });
+    });
+
+    observer.observe(workspaceElement);
+
+    return () => {
+      if (frameId !== null) window.cancelAnimationFrame(frameId);
+      observer.disconnect();
+    };
+  }, [workspaceElement]);
+
+  const handleUpload = async (file: File) => {
+    setError("");
+    try {
+      await documentService.uploadDocument(file);
+      await loadDocuments();
+    } catch (err) {
+      handleApiError(err, "Upload failed");
+    }
+  };
+
+  const handleLogout = async () => {
+    await documentService.logout();
+    handleSessionExpired();
+  };
+
+  const handleDocumentClick = (document: Document) => {
+    if (document.status !== "completed") return;
+    setSelectedDocument(document);
+    setHighlightPage(null);
+    setHighlightSnippet(null);
+    setMobileTab("chat");
+    setSidebarOpen(false);
+  };
+
+  const handleBackToDocuments = () => {
+    setSelectedDocument(null);
+    setHighlightPage(null);
+    setHighlightSnippet(null);
+    setSidebarOpen(true);
+  };
+
+  const handleCitationClick = ({ page, snippet }: CitationTarget) => {
+    const nextSnippet = snippet?.trim() || null;
+    setMobileTab("pdf");
+    setHighlightSnippet(nextSnippet);
+    setHighlightPage((current) => {
+      if (current === page) {
+        setHighlightSnippet(null);
+        window.setTimeout(() => {
+          setHighlightSnippet(nextSnippet);
+          setHighlightPage(page);
+        }, 0);
+        return null;
+      }
+      return page;
+    });
+  };
+
+  const handleProcessDocument = async (doc: Document) => {
+    setError("");
+    try {
+      await documentService.processDocument(doc.id);
+      await loadDocuments();
+    } catch (err) {
+      handleApiError(err, "Failed to queue processing");
+    }
+  };
+
+  const handleDeleteDocument = (doc: Document) => {
+    setDocumentToDelete(doc);
+  };
+
+  const handleCancelDelete = () => {
+    setDocumentToDelete(null);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!documentToDelete) return;
+    const doc = documentToDelete;
+    setDeletingInProgress(true);
+    setError("");
+    try {
+      await documentService.deleteDocument(doc.id);
+      setDocumentToDelete(null);
+      if (selectedDocument?.id === doc.id) setSelectedDocument(null);
+      await loadDocuments();
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        setDocumentToDelete(null);
+      }
+      handleApiError(err, "Failed to delete document");
+    } finally {
+      setDeletingInProgress(false);
+    }
+  };
+
+  return {
+    documents,
+    loading,
+    error,
+    selectedDocument,
+    sidebarOpen,
+    documentToDelete,
+    deletingInProgress,
+    highlightPage,
+    highlightSnippet,
+    mobileTab,
+    useTabLayout,
+    desktopSidebarCollapsed,
+    workspaceElement,
+    isDemoUser,
+    hasActiveDocuments,
+    handleUpload,
+    handleLogout,
+    handleDocumentClick,
+    handleBackToDocuments,
+    handleCitationClick,
+    handleProcessDocument,
+    handleDeleteDocument,
+    handleConfirmDelete,
+    handleCancelDelete,
+    setSidebarOpen,
+    setWorkspaceElement,
+    setMobileTab,
+    setDesktopSidebarCollapsed,
+  };
+}

--- a/frontend/lib/services/documentService.ts
+++ b/frontend/lib/services/documentService.ts
@@ -1,0 +1,29 @@
+import { api, type Document } from "@/lib/api";
+import type { User } from "@/lib/api.types";
+
+export interface DashboardContext {
+  user: User;
+  documents: Document[];
+}
+
+export const documentService = {
+  /** Initial dashboard context load (user + document list) to keep orchestration in one place. */
+  getDashboardContext: async (): Promise<DashboardContext> => {
+    const [user, documentsResponse] = await Promise.all([
+      api.getCurrentUser(),
+      api.getDocuments(),
+    ]);
+
+    return {
+      user,
+      documents: documentsResponse.documents,
+    };
+  },
+
+  getDocuments: () => api.getDocuments(),
+  uploadDocument: (file: File) => api.uploadDocument(file),
+  processDocument: (documentId: number) => api.processDocument(documentId),
+  getDocumentStatus: (documentId: number) => api.getDocumentStatus(documentId),
+  deleteDocument: (documentId: number) => api.deleteDocument(documentId),
+  logout: () => api.logout(),
+};


### PR DESCRIPTION
## Summary
- extract dashboard orchestration into `frontend/lib/hooks/useDashboardState.ts`
- introduce `frontend/lib/services/documentService.ts` to centralize document/user dashboard service calls
- keep `frontend/app/dashboard/page.tsx` as a rendering/wiring layer
- add hook-focused tests for new orchestration logic and keep dashboard page regression coverage

## Verification
- `cd frontend && npm test -- app/dashboard/__tests__/page.test.tsx lib/hooks/__tests__/useDashboardState.test.tsx`
- `cd frontend && npx tsc --noEmit`

Closes #146
