### PR TITLE
Task #151: Frontend auth/home domain services extraction

### DIFF
--- a/frontend/app/__tests__/page.test.tsx
+++ b/frontend/app/__tests__/page.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import Home from "@/app/page";
-import { isLoggedIn, loginAsDemo } from "@/lib/api";
+import { authService } from "@/lib/services/authService";
 
 const pushMock = vi.fn();
 const replaceMock = vi.fn();
@@ -13,29 +13,29 @@ vi.mock("next/navigation", () => ({
   }),
 }));
 
-vi.mock("@/lib/api", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+vi.mock("@/lib/services/authService", () => {
   return {
-    ...actual,
-    isLoggedIn: vi.fn(),
-    loginAsDemo: vi.fn(),
+    authService: {
+      hasActiveSession: vi.fn(),
+      loginDemo: vi.fn(),
+    },
   };
 });
 
-const isLoggedInMock = vi.mocked(isLoggedIn);
-const loginAsDemoMock = vi.mocked(loginAsDemo);
+const hasActiveSessionMock = vi.mocked(authService.hasActiveSession);
+const loginDemoMock = vi.mocked(authService.loginDemo);
 
 describe("Home page Try Demo behavior", () => {
   beforeEach(() => {
     pushMock.mockReset();
     replaceMock.mockReset();
-    isLoggedInMock.mockReset();
-    loginAsDemoMock.mockReset();
-    isLoggedInMock.mockReturnValue(false);
+    hasActiveSessionMock.mockReset();
+    loginDemoMock.mockReset();
+    hasActiveSessionMock.mockReturnValue(false);
   });
 
   it("redirects authenticated users to dashboard", async () => {
-    isLoggedInMock.mockReturnValueOnce(true);
+    hasActiveSessionMock.mockReturnValueOnce(true);
 
     render(<Home />);
 
@@ -45,14 +45,14 @@ describe("Home page Try Demo behavior", () => {
   });
 
   it("logs in demo user and routes directly to dashboard", async () => {
-    loginAsDemoMock.mockResolvedValueOnce();
+    loginDemoMock.mockResolvedValueOnce();
 
     render(<Home />);
 
     fireEvent.click(screen.getByRole("button", { name: "Try Demo" }));
 
     await waitFor(() => {
-      expect(loginAsDemoMock).toHaveBeenCalledTimes(1);
+      expect(loginDemoMock).toHaveBeenCalledTimes(1);
       expect(pushMock).toHaveBeenCalledWith("/dashboard");
     });
   });

--- a/frontend/app/login/__tests__/page.test.tsx
+++ b/frontend/app/login/__tests__/page.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import LoginPage from "@/app/login/page";
-import { api, saveTokens, loginAsDemo } from "@/lib/api";
+import { authService } from "@/lib/services/authService";
 
 const pushMock = vi.fn();
 
@@ -11,22 +11,22 @@ vi.mock("next/navigation", () => ({
   }),
 }));
 
-vi.mock("@/lib/api", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+vi.mock("@/lib/services/authService", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/services/authService")>(
+    "@/lib/services/authService"
+  );
   return {
     ...actual,
-    saveTokens: vi.fn(),
-    loginAsDemo: vi.fn(),
-    api: {
-      ...actual.api,
+    authService: {
+      ...actual.authService,
       login: vi.fn(),
+      loginDemo: vi.fn(),
     },
   };
 });
 
-const loginMock = vi.mocked(api.login);
-const saveTokensMock = vi.mocked(saveTokens);
-const loginAsDemoMock = vi.mocked(loginAsDemo);
+const loginMock = vi.mocked(authService.login);
+const loginDemoMock = vi.mocked(authService.loginDemo);
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -42,12 +42,11 @@ describe("LoginPage form behavior", () => {
   beforeEach(() => {
     pushMock.mockReset();
     loginMock.mockReset();
-    saveTokensMock.mockReset();
-    loginAsDemoMock.mockReset();
+    loginDemoMock.mockReset();
   });
 
   it("disables submit while login is in flight and re-enables after success", async () => {
-    const pending = deferred<{ csrf_token: string; token_type: string }>();
+    const pending = deferred<void>();
     loginMock.mockReturnValueOnce(pending.promise);
 
     render(<LoginPage />);
@@ -62,13 +61,9 @@ describe("LoginPage form behavior", () => {
 
     expect(screen.getByRole("button", { name: "Accessing..." })).toBeDisabled();
 
-    pending.resolve({ csrf_token: "csrf-token", token_type: "bearer" });
+    pending.resolve();
 
     await waitFor(() => {
-      expect(saveTokensMock).toHaveBeenCalledWith({
-        csrf_token: "csrf-token",
-        token_type: "bearer",
-      });
       expect(pushMock).toHaveBeenCalledWith("/dashboard");
       expect(screen.getByRole("button", { name: "Sign In" })).toBeEnabled();
     });
@@ -92,14 +87,14 @@ describe("LoginPage form behavior", () => {
   });
 
   it("logs in with demo credentials from the Try Demo button", async () => {
-    loginAsDemoMock.mockResolvedValueOnce();
+    loginDemoMock.mockResolvedValueOnce();
 
     render(<LoginPage />);
 
     fireEvent.click(screen.getByRole("button", { name: "Try Demo" }));
 
     await waitFor(() => {
-      expect(loginAsDemoMock).toHaveBeenCalledTimes(1);
+      expect(loginDemoMock).toHaveBeenCalledTimes(1);
       expect(pushMock).toHaveBeenCalledWith("/dashboard");
     });
 

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -6,11 +6,11 @@
 import { useState, type SyntheticEvent } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { api, saveTokens, loginAsDemo } from "@/lib/api";
+import { authService } from "@/lib/services/authService";
 
 /**
- * Renders centered login form. Submits to api.login, saves csrf_token to
- * localStorage, then redirects to /dashboard. Link to register for new users.
+ * Renders centered login form. Submits via auth service and redirects to
+ * /dashboard. Link to register for new users.
  */
 export default function LoginPage() {
   const [username, setUsername] = useState("");
@@ -24,11 +24,10 @@ export default function LoginPage() {
     setLoading(true);
 
     try {
-      const response = await api.login({
+      await authService.login({
         username: nextUsername,
         password: nextPassword,
       });
-      saveTokens(response);
       router.push("/dashboard");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Login failed");
@@ -49,7 +48,7 @@ export default function LoginPage() {
     setLoading(true);
 
     try {
-      await loginAsDemo();
+      await authService.loginDemo();
       router.push("/dashboard");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Login failed");

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,7 +7,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { isLoggedIn, loginAsDemo } from "@/lib/api";
+import { authService } from "@/lib/services/authService";
 
 export default function Home() {
   const router = useRouter();
@@ -15,7 +15,7 @@ export default function Home() {
   const [error, setError] = useState("");
 
   useEffect(() => {
-    if (isLoggedIn()) {
+    if (authService.hasActiveSession()) {
       router.replace("/dashboard");
     }
   }, [router]);
@@ -24,7 +24,7 @@ export default function Home() {
     setError("");
     setLoadingDemo(true);
     try {
-      await loginAsDemo();
+      await authService.loginDemo();
       router.push("/dashboard");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Demo login failed");

--- a/frontend/app/register/__tests__/page.test.tsx
+++ b/frontend/app/register/__tests__/page.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import RegisterPage from "@/app/register/page";
-import { api, saveTokens } from "@/lib/api";
+import { authService } from "@/lib/services/authService";
 
 const pushMock = vi.fn();
 
@@ -11,22 +11,20 @@ vi.mock("next/navigation", () => ({
   }),
 }));
 
-vi.mock("@/lib/api", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+vi.mock("@/lib/services/authService", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/services/authService")>(
+    "@/lib/services/authService"
+  );
   return {
     ...actual,
-    saveTokens: vi.fn(),
-    api: {
-      ...actual.api,
-      register: vi.fn(),
-      login: vi.fn(),
+    authService: {
+      ...actual.authService,
+      registerAndLogin: vi.fn(),
     },
   };
 });
 
-const registerMock = vi.mocked(api.register);
-const loginMock = vi.mocked(api.login);
-const saveTokensMock = vi.mocked(saveTokens);
+const registerAndLoginMock = vi.mocked(authService.registerAndLogin);
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -41,24 +39,12 @@ function deferred<T>() {
 describe("RegisterPage form behavior", () => {
   beforeEach(() => {
     pushMock.mockReset();
-    registerMock.mockReset();
-    loginMock.mockReset();
-    saveTokensMock.mockReset();
+    registerAndLoginMock.mockReset();
   });
 
   it("disables submit while registering and re-enables after success", async () => {
-    const pendingRegistration = deferred<{
-      id: number;
-      username: string;
-      email: string;
-      is_demo: boolean;
-      created_at: string;
-    }>();
-    registerMock.mockReturnValueOnce(pendingRegistration.promise);
-    loginMock.mockResolvedValueOnce({
-      csrf_token: "csrf-token",
-      token_type: "bearer",
-    });
+    const pendingRegistration = deferred<void>();
+    registerAndLoginMock.mockReturnValueOnce(pendingRegistration.promise);
 
     render(<RegisterPage />);
 
@@ -77,27 +63,13 @@ describe("RegisterPage form behavior", () => {
       screen.getByRole("button", { name: "Creating account..." })
     ).toBeDisabled();
 
-    pendingRegistration.resolve({
-      id: 1,
-      username: "alice",
-      email: "alice@example.com",
-      is_demo: false,
-      created_at: "2026-03-02T10:00:00Z",
-    });
+    pendingRegistration.resolve();
 
     await waitFor(() => {
-      expect(registerMock).toHaveBeenCalledWith({
+      expect(registerAndLoginMock).toHaveBeenCalledWith({
         username: "alice",
         email: "alice@example.com",
         password: "strong-password",
-      });
-      expect(loginMock).toHaveBeenCalledWith({
-        username: "alice",
-        password: "strong-password",
-      });
-      expect(saveTokensMock).toHaveBeenCalledWith({
-        csrf_token: "csrf-token",
-        token_type: "bearer",
       });
       expect(pushMock).toHaveBeenCalledWith("/dashboard");
       expect(screen.getByRole("button", { name: "Register" })).toBeEnabled();
@@ -105,7 +77,7 @@ describe("RegisterPage form behavior", () => {
   });
 
   it("renders API errors and re-enables submit", async () => {
-    registerMock.mockRejectedValueOnce(new Error("Username already exists"));
+    registerAndLoginMock.mockRejectedValueOnce(new Error("Username already exists"));
 
     render(<RegisterPage />);
 

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -7,11 +7,11 @@
 import { useState, type SyntheticEvent } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { api, saveTokens } from "@/lib/api";
+import { authService } from "@/lib/services/authService";
 
 /**
- * Renders centered registration form. On submit: api.register, then api.login
- * to get csrf token and redirect. Link to login for existing users.
+ * Renders centered registration form. On submit: register + auto-login via
+ * auth service, then redirect. Link to login for existing users.
  */
 export default function RegisterPage() {
   const [username, setUsername] = useState("");
@@ -27,11 +27,7 @@ export default function RegisterPage() {
     setLoading(true);
 
     try {
-      await api.register({ username, email, password });
-
-      // Auto-login after registration
-      const loginResponse = await api.login({ username, password });
-      saveTokens(loginResponse);
+      await authService.registerAndLogin({ username, email, password });
       router.push("/dashboard");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Registration failed");

--- a/frontend/lib/services/__tests__/authService.test.ts
+++ b/frontend/lib/services/__tests__/authService.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authService } from "@/lib/services/authService";
+import { api, isLoggedIn, saveTokens } from "@/lib/api";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    isLoggedIn: vi.fn(),
+    saveTokens: vi.fn(),
+    api: {
+      ...actual.api,
+      login: vi.fn(),
+      register: vi.fn(),
+      logout: vi.fn(),
+    },
+  };
+});
+
+const isLoggedInMock = vi.mocked(isLoggedIn);
+const saveTokensMock = vi.mocked(saveTokens);
+const loginMock = vi.mocked(api.login);
+const registerMock = vi.mocked(api.register);
+const logoutMock = vi.mocked(api.logout);
+
+describe("authService", () => {
+  beforeEach(() => {
+    isLoggedInMock.mockReset();
+    saveTokensMock.mockReset();
+    loginMock.mockReset();
+    registerMock.mockReset();
+    logoutMock.mockReset();
+  });
+
+  it("returns local session state from hasActiveSession", () => {
+    isLoggedInMock.mockReturnValueOnce(true);
+
+    expect(authService.hasActiveSession()).toBe(true);
+    expect(isLoggedInMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs in and persists returned tokens", async () => {
+    loginMock.mockResolvedValueOnce({
+      csrf_token: "csrf-token",
+      token_type: "bearer",
+    });
+
+    await authService.login({ username: "alice", password: "secret" });
+
+    expect(loginMock).toHaveBeenCalledWith({
+      username: "alice",
+      password: "secret",
+    });
+    expect(saveTokensMock).toHaveBeenCalledWith({
+      csrf_token: "csrf-token",
+      token_type: "bearer",
+    });
+  });
+
+  it("registers then logs in with the same credentials", async () => {
+    registerMock.mockResolvedValueOnce({
+      id: 1,
+      username: "alice",
+      email: "alice@example.com",
+      is_demo: false,
+      created_at: "2026-03-08T10:00:00Z",
+    });
+    loginMock.mockResolvedValueOnce({
+      csrf_token: "csrf-token",
+      token_type: "bearer",
+    });
+
+    await authService.registerAndLogin({
+      username: "alice",
+      email: "alice@example.com",
+      password: "strong-password",
+    });
+
+    expect(registerMock).toHaveBeenCalledWith({
+      username: "alice",
+      email: "alice@example.com",
+      password: "strong-password",
+    });
+    expect(loginMock).toHaveBeenCalledWith({
+      username: "alice",
+      password: "strong-password",
+    });
+    expect(saveTokensMock).toHaveBeenCalledWith({
+      csrf_token: "csrf-token",
+      token_type: "bearer",
+    });
+  });
+
+  it("logs in with seeded demo credentials", async () => {
+    loginMock.mockResolvedValueOnce({
+      csrf_token: "csrf-token",
+      token_type: "bearer",
+    });
+
+    await authService.loginDemo();
+
+    expect(loginMock).toHaveBeenCalledWith({
+      username: "demo",
+      password: "demo",
+    });
+  });
+
+  it("delegates logout to api logout", async () => {
+    logoutMock.mockResolvedValueOnce();
+
+    await authService.logout();
+
+    expect(logoutMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/lib/services/__tests__/chatService.test.ts
+++ b/frontend/lib/services/__tests__/chatService.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { chatService } from "@/lib/services/chatService";
+import { api } from "@/lib/api";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getMessages: vi.fn(),
+      queryDocument: vi.fn(),
+      queryDocumentStream: vi.fn(),
+    },
+  };
+});
+
+const getMessagesMock = vi.mocked(api.getMessages);
+const queryDocumentMock = vi.mocked(api.queryDocument);
+const queryDocumentStreamMock = vi.mocked(api.queryDocumentStream);
+
+describe("chatService", () => {
+  beforeEach(() => {
+    getMessagesMock.mockReset();
+    queryDocumentMock.mockReset();
+    queryDocumentStreamMock.mockReset();
+  });
+
+  it("loads document messages", async () => {
+    getMessagesMock.mockResolvedValueOnce({ messages: [], total: 0 });
+
+    const result = await chatService.getMessages(42);
+
+    expect(getMessagesMock).toHaveBeenCalledWith(42);
+    expect(result).toEqual({ messages: [], total: 0 });
+  });
+
+  it("submits a non-streaming query", async () => {
+    queryDocumentMock.mockResolvedValueOnce({
+      query: "What is this?",
+      answer: "Answer text",
+      sources: [],
+      pipeline_meta: undefined,
+    });
+
+    const result = await chatService.queryDocument(42, "What is this?");
+
+    expect(queryDocumentMock).toHaveBeenCalledWith(42, "What is this?");
+    expect(result.answer).toBe("Answer text");
+  });
+
+  it("starts streaming query with provided callbacks and options", async () => {
+    queryDocumentStreamMock.mockResolvedValueOnce();
+    const callbacks = {
+      onSources: vi.fn(),
+      onToken: vi.fn(),
+      onMeta: vi.fn(),
+      onDone: vi.fn(),
+      onError: vi.fn(),
+    };
+    const options = { signal: new AbortController().signal };
+
+    await chatService.queryDocumentStream(42, "stream question", callbacks, options);
+
+    expect(queryDocumentStreamMock).toHaveBeenCalledWith(
+      42,
+      "stream question",
+      callbacks,
+      options
+    );
+  });
+});

--- a/frontend/lib/services/authService.ts
+++ b/frontend/lib/services/authService.ts
@@ -1,0 +1,36 @@
+import { api, isLoggedIn, saveTokens } from "@/lib/api";
+import type { LoginCredentials, RegisterData } from "@/lib/api.types";
+
+const DEMO_CREDENTIALS: LoginCredentials = {
+  username: "demo",
+  password: "demo",
+};
+
+export const authService = {
+  /** Fast client-side session check for routing decisions. */
+  hasActiveSession: (): boolean => isLoggedIn(),
+
+  /** Login and persist the returned CSRF token for subsequent mutating requests. */
+  login: async (credentials: LoginCredentials): Promise<void> => {
+    const response = await api.login(credentials);
+    saveTokens(response);
+  },
+
+  /** Register a user, then login and persist CSRF token. */
+  registerAndLogin: async (data: RegisterData): Promise<void> => {
+    await api.register(data);
+    await authService.login({
+      username: data.username,
+      password: data.password,
+    });
+  },
+
+  /** Login using the seeded demo account. */
+  loginDemo: async (): Promise<void> => {
+    await authService.login(DEMO_CREDENTIALS);
+  },
+
+  logout: async (): Promise<void> => {
+    await api.logout();
+  },
+};

--- a/frontend/lib/services/chatService.ts
+++ b/frontend/lib/services/chatService.ts
@@ -1,0 +1,33 @@
+import { api, type QueryResponse } from "@/lib/api";
+import type { MessageListResponse, PipelineMeta } from "@/lib/api.types";
+
+interface QueryStreamCallbacks {
+  onSources: (sources: QueryResponse["sources"]) => void;
+  onToken: (token: string) => void;
+  onMeta: (meta: PipelineMeta) => void;
+  onDone: (data: { message_id: number }) => void;
+  onError: (detail: string) => void;
+}
+
+interface QueryStreamOptions {
+  signal?: AbortSignal;
+}
+
+export const chatService = {
+  getMessages: async (documentId: number): Promise<MessageListResponse> => {
+    return api.getMessages(documentId);
+  },
+
+  queryDocument: async (documentId: number, query: string): Promise<QueryResponse> => {
+    return api.queryDocument(documentId, query);
+  },
+
+  queryDocumentStream: async (
+    documentId: number,
+    query: string,
+    callbacks: QueryStreamCallbacks,
+    options: QueryStreamOptions = {}
+  ): Promise<void> => {
+    await api.queryDocumentStream(documentId, query, callbacks, options);
+  },
+};


### PR DESCRIPTION
## Summary
- add `authService` with domain-level auth orchestration (session check, login + token persistence, register+auto-login, demo login)
- add `chatService` boundary module for chat history/query operations
- migrate auth/home callers (`/`, `/login`, `/register`) to use `authService` instead of direct auth API orchestration
- update page tests and add focused service tests for `authService` and `chatService`

## Verification
- `cd frontend && npm test -- app/__tests__/page.test.tsx app/login/__tests__/page.test.tsx app/register/__tests__/page.test.tsx lib/services/__tests__/*.test.ts`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npx eslint app/page.tsx app/login/page.tsx app/register/page.tsx app/__tests__/page.test.tsx app/login/__tests__/page.test.tsx app/register/__tests__/page.test.tsx lib/services/authService.ts lib/services/chatService.ts lib/services/documentService.ts lib/services/__tests__/authService.test.ts lib/services/__tests__/chatService.test.ts`

## Notes
- repository-wide lint command currently fails in untouched files (`frontend/lib/__tests__/api.auth.test.ts`, `frontend/lib/hooks/__tests__/useDashboardState.test.tsx`), so lint verification here is scoped to Task-touched files.

Closes #151
