### PR TITLE
Refactor: extract chat orchestration into useChatState

### DIFF
--- a/frontend/app/components/dashboard/ChatWindow.tsx
+++ b/frontend/app/components/dashboard/ChatWindow.tsx
@@ -5,26 +5,11 @@
 
 "use client";
 
-import { useState, useRef, useEffect, SyntheticEvent } from "react";
+import { SyntheticEvent, useEffect, useRef, useState } from "react";
 import { ArrowLeft, Settings2 } from "lucide-react";
-import {
-  type Document,
-  api,
-  type QueryResponse,
-  type PipelineMeta,
-  ApiError,
-  SessionExpiredError,
-} from "@/lib/api";
 import { formatDate } from "@/lib/utils";
-
-interface Message {
-  role: "user" | "assistant";
-  content: string;
-  sources?: QueryResponse["sources"];
-  pipeline_meta?: PipelineMeta;
-  streaming?: boolean;
-  retry_query?: string;
-}
+import type { Document } from "@/lib/api";
+import { useChatState } from "@/lib/hooks/useChatState";
 
 interface CitationTarget {
   page: number;
@@ -56,24 +41,15 @@ export function ChatWindow({
   onCitationClick,
   onSessionExpired,
 }: ChatWindowProps) {
-  const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
-  const [loadingHistory, setLoadingHistory] = useState(true);
   const [debugMode, setDebugMode] = useState(false);
   const [expandedSourceIndices, setExpandedSourceIndices] = useState<Set<number>>(new Set());
   const [expandedSourceCards, setExpandedSourceCards] = useState<Set<string>>(new Set());
   const scrollRef = useRef<HTMLDivElement>(null);
-  const isMountedRef = useRef(true);
-  const activeStreamAbortRef = useRef<AbortController | null>(null);
-  const streamInFlightRef = useRef(false);
-  const isStreaming = messages.some((message) => message.streaming);
-
-  const isAbortError = (err: unknown): boolean => {
-    return (
-      (err instanceof DOMException && err.name === "AbortError")
-      || (typeof err === "object" && err !== null && "name" in err && err.name === "AbortError")
-    );
-  };
+  const { messages, loadingHistory, isStreaming, submitQuery, stopActiveStream } = useChatState({
+    document,
+    onSessionExpired,
+  });
 
   /** Toggle whether the whole "Sources" block for a message is open or collapsed. */
   const toggleSources = (messageIndex: number) => {
@@ -107,96 +83,10 @@ export function ChatWindow({
     }
   };
 
-  const updateStreamingAssistant = (updater: (message: Message) => Message) => {
-    setMessages((prev) => {
-      const streamingIndex = prev.findIndex(
-        (message) => message.role === "assistant" && message.streaming
-      );
-      if (streamingIndex === -1) return prev;
-
-      const next = [...prev];
-      next[streamingIndex] = updater(next[streamingIndex]);
-      return next;
-    });
-  };
-
-  const appendStreamError = (errorMessage: string, retryQuery: string) => {
-    setMessages((prev) => {
-      const streamingIndex = prev.findIndex(
-        (message) => message.role === "assistant" && message.streaming
-      );
-      if (streamingIndex === -1) {
-        return [...prev, { role: "assistant", content: errorMessage, retry_query: retryQuery }];
-      }
-
-      const next = [...prev];
-      const current = next[streamingIndex];
-      next[streamingIndex] = {
-        ...current,
-        content: current.content ? `${current.content}\n\n${errorMessage}` : errorMessage,
-        streaming: false,
-        retry_query: retryQuery,
-      };
-      return next;
-    });
-  };
-
-  const markStreamStopped = (retryQuery: string) => {
-    updateStreamingAssistant((message) => ({
-      ...message,
-      content: message.content
-        ? `${message.content}\n\nStopped. You can retry this response.`
-        : "Stopped. You can retry this response.",
-      streaming: false,
-      retry_query: retryQuery,
-    }));
-  };
-
-  const stopActiveStream = () => {
-    activeStreamAbortRef.current?.abort();
-  };
-
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-      activeStreamAbortRef.current?.abort();
-      streamInFlightRef.current = false;
-    };
-  }, []);
-
   useEffect(() => {
     if (typeof window === "undefined") return;
     setDebugMode(localStorage.getItem(DEBUG_MODE_STORAGE_KEY) === "true");
   }, []);
-
-
-  useEffect(() => {
-    const loadHistory = async () => {
-      try {
-        setLoadingHistory(true);
-        const response = await api.getMessages(document.id);
-
-        const loadedMessages: Message[] = response.messages.map((msg) => ({
-          role: msg.role,
-          content: msg.content,
-          sources: msg.sources as QueryResponse["sources"],
-          pipeline_meta: msg.pipeline_meta,
-        }));
-        setMessages(loadedMessages);
-      } catch (err) {
-        if (err instanceof SessionExpiredError) {
-          onSessionExpired?.();
-          return;
-        }
-        console.error("Failed to load message history:", err);
-      } finally {
-        setLoadingHistory(false);
-      }
-    };
-
-    loadHistory();
-  }, [document.id, onSessionExpired]);
 
   // Auto-scroll to bottom when messages change
   useEffect(() => {
@@ -205,102 +95,12 @@ export function ChatWindow({
     }
   }, [messages]);
 
-
-
-
-  const submitQuery = async (query: string) => {
-    const trimmed = query.trim();
-    if (!trimmed || isStreaming || streamInFlightRef.current) return;
-
-    streamInFlightRef.current = true;
-    const streamController = new AbortController();
-    activeStreamAbortRef.current?.abort();
-    activeStreamAbortRef.current = streamController;
-
-    setInput("");
-    setMessages((prev) => [
-      ...prev,
-      { role: "user", content: trimmed },
-      { role: "assistant", content: "", streaming: true },
-    ]);
-
-    try {
-      await api.queryDocumentStream(document.id, trimmed, {
-        onSources: (sources) => {
-          if (!isMountedRef.current || streamController.signal.aborted) return;
-          updateStreamingAssistant((message) => ({
-            ...message,
-            sources,
-          }));
-        },
-        onToken: (token) => {
-          if (!isMountedRef.current || streamController.signal.aborted) return;
-          updateStreamingAssistant((message) => ({
-            ...message,
-            content: `${message.content}${token}`,
-          }));
-        },
-        onMeta: (pipelineMeta) => {
-          if (!isMountedRef.current || streamController.signal.aborted) return;
-          updateStreamingAssistant((message) => ({
-            ...message,
-            pipeline_meta: pipelineMeta,
-          }));
-        },
-        onDone: () => {
-          if (!isMountedRef.current || streamController.signal.aborted) return;
-          updateStreamingAssistant((message) => ({
-            ...message,
-            streaming: false,
-          }));
-          activeStreamAbortRef.current = null;
-          streamInFlightRef.current = false;
-        },
-        onError: (detail) => {
-          if (!isMountedRef.current || streamController.signal.aborted) return;
-          appendStreamError(`Error: ${detail}`, trimmed);
-          activeStreamAbortRef.current = null;
-          streamInFlightRef.current = false;
-        },
-      }, { signal: streamController.signal });
-    } catch (err) {
-      if (isAbortError(err)) {
-        if (isMountedRef.current) {
-          markStreamStopped(trimmed);
-        }
-        streamInFlightRef.current = false;
-        return;
-      }
-
-      let errorMessage = "Error: Failed to get answer. Please try again.";
-
-      if (err instanceof ApiError) {
-        if (err.status === 400) {
-          errorMessage = "This document hasn't been processed yet. Please process it first before asking questions.";
-        } else if (err.status === 404) {
-          errorMessage = "Document not found.";
-        } else if (err instanceof SessionExpiredError) {
-          onSessionExpired?.();
-          return;
-        } else if (err.status === 401) {
-          errorMessage = "Your session has expired. Please log in again.";
-        } else {
-          errorMessage = `Error: ${err.detail}`;
-        }
-      }
-
-      appendStreamError(errorMessage, trimmed);
-    } finally {
-      if (activeStreamAbortRef.current === streamController) {
-        activeStreamAbortRef.current = null;
-      }
-      streamInFlightRef.current = false;
-    }
-  };
-
   const handleSubmit = (e: SyntheticEvent) => {
     e.preventDefault();
-    void submitQuery(input);
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    setInput("");
+    void submitQuery(trimmed);
   };
 
   const handleRetry = (query: string) => {
@@ -481,7 +281,7 @@ export function ChatWindow({
                   <span>
                     {(msg.pipeline_meta.total_ms / 1000).toFixed(1)}s ·{" "}
                     {(msg.pipeline_meta.avg_similarity * 100).toFixed(0)}% retrieval ·{" "}
-                    {msg.pipeline_meta.chunks_retrieved}{" "}
+                    {msg.pipeline_meta.chunks_retrieved} {" "}
                     {msg.pipeline_meta.chunks_retrieved === 1 ? "source" : "sources"} ·{" "}
                     {getConfidence(msg.pipeline_meta.top_similarity)} confidence
                   </span>

--- a/frontend/app/components/dashboard/__tests__/ChatWindow.streaming.test.tsx
+++ b/frontend/app/components/dashboard/__tests__/ChatWindow.streaming.test.tsx
@@ -1,23 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ChatWindow } from "@/app/components/dashboard/ChatWindow";
-import { api } from "@/lib/api";
+import { chatService } from "@/lib/services/chatService";
 import type { Document, PipelineMeta, QueryResponse } from "@/lib/api";
 
-vi.mock("@/lib/api", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+vi.mock("@/lib/services/chatService", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/services/chatService")>(
+    "@/lib/services/chatService"
+  );
   return {
     ...actual,
-    api: {
-      ...actual.api,
+    chatService: {
+      ...actual.chatService,
       getMessages: vi.fn(),
       queryDocumentStream: vi.fn(),
     },
   };
 });
 
-const getMessagesMock = vi.mocked(api.getMessages);
-const queryDocumentStreamMock = vi.mocked(api.queryDocumentStream);
+const getMessagesMock = vi.mocked(chatService.getMessages);
+const queryDocumentStreamMock = vi.mocked(chatService.queryDocumentStream);
 
 interface StreamCallbacks {
   onSources: (sources: QueryResponse["sources"]) => void;

--- a/frontend/lib/hooks/__tests__/useChatState.test.tsx
+++ b/frontend/lib/hooks/__tests__/useChatState.test.tsx
@@ -1,0 +1,178 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Document, PipelineMeta, QueryResponse } from "@/lib/api";
+import { useChatState } from "@/lib/hooks/useChatState";
+import { chatService } from "@/lib/services/chatService";
+import { SessionExpiredError } from "@/lib/api";
+
+vi.mock("@/lib/services/chatService", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/services/chatService")>(
+    "@/lib/services/chatService"
+  );
+  return {
+    ...actual,
+    chatService: {
+      ...actual.chatService,
+      getMessages: vi.fn(),
+      queryDocumentStream: vi.fn(),
+    },
+  };
+});
+
+const getMessagesMock = vi.mocked(chatService.getMessages);
+const queryDocumentStreamMock = vi.mocked(chatService.queryDocumentStream);
+
+interface StreamCallbacks {
+  onSources: (sources: QueryResponse["sources"]) => void;
+  onToken: (token: string) => void;
+  onMeta: (meta: PipelineMeta) => void;
+  onDone: (data: { message_id: number }) => void;
+  onError: (detail: string) => void;
+}
+
+const documentFixture: Document = {
+  id: 7,
+  user_id: 1,
+  filename: "guide.pdf",
+  file_size: 1024,
+  status: "completed",
+  uploaded_at: "2026-03-02T12:00:00Z",
+  processed_at: "2026-03-02T12:01:00Z",
+  error_message: null,
+};
+
+function setupHookHarness(onSessionExpired = vi.fn()) {
+  const stateRef: {
+    current: ReturnType<typeof useChatState> | null;
+  } = { current: null };
+
+  const HookHarness = () => {
+    stateRef.current = useChatState({ document: documentFixture, onSessionExpired });
+    return null;
+  };
+
+  render(<HookHarness />);
+  return { stateRef, onSessionExpired };
+}
+
+describe("useChatState", () => {
+  beforeEach(() => {
+    getMessagesMock.mockResolvedValue({ messages: [], total: 0 });
+    queryDocumentStreamMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads history into state on mount", async () => {
+    getMessagesMock.mockResolvedValueOnce({
+      messages: [
+        {
+          id: 11,
+          document_id: documentFixture.id,
+          user_id: documentFixture.user_id,
+          role: "assistant",
+          content: "History answer",
+          created_at: "2026-03-02T12:03:00Z",
+        },
+      ],
+      total: 1,
+    });
+
+    const { stateRef } = setupHookHarness();
+
+    await waitFor(() => {
+      expect(stateRef.current?.loadingHistory).toBe(false);
+    });
+
+    expect(stateRef.current?.messages).toEqual([
+      {
+        role: "assistant",
+        content: "History answer",
+      },
+    ]);
+  });
+
+  it("redirects when history load is rejected as session expired", async () => {
+    const onSessionExpired = vi.fn();
+    getMessagesMock.mockRejectedValueOnce(new SessionExpiredError());
+
+    setupHookHarness(onSessionExpired);
+
+    await waitFor(() => {
+      expect(onSessionExpired).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("redirects when query stream fails with session expired", async () => {
+    const onSessionExpired = vi.fn();
+    queryDocumentStreamMock.mockRejectedValueOnce(new SessionExpiredError("Session expired"));
+
+    const { stateRef } = setupHookHarness(onSessionExpired);
+    await waitFor(() => {
+      expect(stateRef.current?.loadingHistory).toBe(false);
+    });
+
+    await act(async () => {
+      await stateRef.current?.submitQuery("What does it say?");
+    });
+
+    await waitFor(() => {
+      expect(onSessionExpired).toHaveBeenCalledTimes(1);
+      expect(queryDocumentStreamMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("supports stream stop + retry callback behavior", async () => {
+    let capturedCallbacks: StreamCallbacks | undefined;
+    let capturedSignal: AbortSignal | undefined;
+
+    queryDocumentStreamMock.mockImplementationOnce(async (_documentId, _query, callbacks, options) => {
+      capturedCallbacks = callbacks as StreamCallbacks;
+      capturedSignal = options?.signal;
+      await new Promise<void>((resolve, reject) => {
+        if (!capturedSignal) {
+          resolve();
+          return;
+        }
+
+        capturedSignal.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"));
+        }, { once: true });
+      });
+    });
+
+    queryDocumentStreamMock.mockImplementationOnce(async (_documentId, _query, callbacks) => {
+      await Promise.resolve();
+      callbacks.onToken("Recovered");
+      callbacks.onDone({ message_id: 301 });
+    });
+
+    const { stateRef } = setupHookHarness();
+
+    await waitFor(() => {
+      expect(stateRef.current?.loadingHistory).toBe(false);
+    });
+
+    await act(async () => {
+      const firstSubmit = stateRef.current?.submitQuery("Original question");
+      stateRef.current?.stopActiveStream();
+      capturedCallbacks?.onToken("should be ignored after stop");
+      await firstSubmit;
+      await stateRef.current?.submitQuery("Original question");
+    });
+
+    await waitFor(() => {
+      expect(queryDocumentStreamMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(queryDocumentStreamMock.mock.calls[0]?.[1]).toBe("Original question");
+    expect(queryDocumentStreamMock.mock.calls[1]?.[1]).toBe("Original question");
+    expect(stateRef.current?.messages.some((message) => message.content.includes("Recovered"))).toBe(
+      true
+    );
+    expect(stateRef.current?.messages.at(-1)?.retry_query).toBeUndefined();
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+});

--- a/frontend/lib/hooks/useChatState.ts
+++ b/frontend/lib/hooks/useChatState.ts
@@ -1,0 +1,243 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ApiError, SessionExpiredError, type Document, type PipelineMeta, type QueryResponse } from "@/lib/api";
+import { chatService } from "@/lib/services/chatService";
+
+export interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+  sources?: QueryResponse["sources"];
+  pipeline_meta?: PipelineMeta;
+  streaming?: boolean;
+  retry_query?: string;
+}
+
+interface QueryStreamCallbacks {
+  onSources: (sources: QueryResponse["sources"]) => void;
+  onToken: (token: string) => void;
+  onMeta: (meta: PipelineMeta) => void;
+  onDone: (data: { message_id: number }) => void;
+  onError: (detail: string) => void;
+}
+
+interface UseChatStateOptions {
+  document: Document;
+  onSessionExpired?: () => void;
+}
+
+export interface UseChatStateResult {
+  messages: ChatMessage[];
+  loadingHistory: boolean;
+  isStreaming: boolean;
+  submitQuery: (query: string) => Promise<void>;
+  stopActiveStream: () => void;
+}
+
+const isAbortError = (err: unknown): boolean => {
+  return (
+    (err instanceof DOMException && err.name === "AbortError")
+    || (typeof err === "object" && err !== null && "name" in err && err.name === "AbortError")
+  );
+};
+
+export function useChatState({
+  document,
+  onSessionExpired,
+}: UseChatStateOptions): UseChatStateResult {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [loadingHistory, setLoadingHistory] = useState(true);
+  const activeStreamAbortRef = useRef<AbortController | null>(null);
+  const streamInFlightRef = useRef(false);
+  const isMountedRef = useRef(true);
+  const isStreaming = messages.some((message) => message.role === "assistant" && message.streaming);
+
+  const handleSessionExpired = useCallback(() => {
+    onSessionExpired?.();
+  }, [onSessionExpired]);
+
+  const updateStreamingAssistant = useCallback((updater: (message: ChatMessage) => ChatMessage) => {
+    setMessages((prev) => {
+      const streamingIndex = prev.findIndex(
+        (message) => message.role === "assistant" && message.streaming
+      );
+      if (streamingIndex === -1) return prev;
+
+      const next = [...prev];
+      next[streamingIndex] = updater(next[streamingIndex]);
+      return next;
+    });
+  }, []);
+
+  const appendStreamError = useCallback((errorMessage: string, retryQuery: string) => {
+    setMessages((prev) => {
+      const streamingIndex = prev.findIndex(
+        (message) => message.role === "assistant" && message.streaming
+      );
+      if (streamingIndex === -1) {
+        return [...prev, { role: "assistant", content: errorMessage, retry_query: retryQuery }];
+      }
+
+      const next = [...prev];
+      const current = next[streamingIndex];
+      next[streamingIndex] = {
+        ...current,
+        content: current.content ? `${current.content}\n\n${errorMessage}` : errorMessage,
+        streaming: false,
+        retry_query: retryQuery,
+      };
+      return next;
+    });
+  }, []);
+
+  const markStreamStopped = useCallback((retryQuery: string) => {
+    updateStreamingAssistant((message) => ({
+      ...message,
+      content: message.content
+        ? `${message.content}\n\nStopped. You can retry this response.`
+        : "Stopped. You can retry this response.",
+      streaming: false,
+      retry_query: retryQuery,
+    }));
+  }, [updateStreamingAssistant]);
+
+  const stopActiveStream = useCallback(() => {
+    activeStreamAbortRef.current?.abort();
+  }, []);
+
+  const submitQuery = useCallback(async (query: string) => {
+    const trimmed = query.trim();
+    if (!trimmed || streamInFlightRef.current) return;
+
+    streamInFlightRef.current = true;
+    const streamController = new AbortController();
+    activeStreamAbortRef.current?.abort();
+    activeStreamAbortRef.current = streamController;
+
+    setMessages((prev) => [
+      ...prev,
+      { role: "user", content: trimmed },
+      { role: "assistant", content: "", streaming: true },
+    ]);
+
+    const callbacks: QueryStreamCallbacks = {
+      onSources: (sources) => {
+        if (!isMountedRef.current || streamController.signal.aborted) return;
+        updateStreamingAssistant((message) => ({
+          ...message,
+          sources,
+        }));
+      },
+      onToken: (token) => {
+        if (!isMountedRef.current || streamController.signal.aborted) return;
+        updateStreamingAssistant((message) => ({
+          ...message,
+          content: `${message.content}${token}`,
+        }));
+      },
+      onMeta: (pipelineMeta) => {
+        if (!isMountedRef.current || streamController.signal.aborted) return;
+        updateStreamingAssistant((message) => ({
+          ...message,
+          pipeline_meta: pipelineMeta,
+        }));
+      },
+      onDone: () => {
+        if (!isMountedRef.current || streamController.signal.aborted) return;
+        updateStreamingAssistant((message) => ({
+          ...message,
+          streaming: false,
+        }));
+        activeStreamAbortRef.current = null;
+        streamInFlightRef.current = false;
+      },
+      onError: (detail) => {
+        if (!isMountedRef.current || streamController.signal.aborted) return;
+        appendStreamError(`Error: ${detail}`, trimmed);
+        activeStreamAbortRef.current = null;
+        streamInFlightRef.current = false;
+      },
+    };
+
+    try {
+      await chatService.queryDocumentStream(document.id, trimmed, callbacks, {
+        signal: streamController.signal,
+      });
+    } catch (err) {
+      if (isAbortError(err)) {
+        if (isMountedRef.current) {
+          markStreamStopped(trimmed);
+        }
+        streamInFlightRef.current = false;
+        return;
+      }
+
+      let errorMessage = "Error: Failed to get answer. Please try again.";
+
+      if (err instanceof ApiError) {
+        if (err.status === 400) {
+          errorMessage =
+            "This document hasn't been processed yet. Please process it first before asking questions.";
+        } else if (err.status === 404) {
+          errorMessage = "Document not found.";
+        } else if (err instanceof SessionExpiredError) {
+          handleSessionExpired();
+          return;
+        } else if (err.status === 401) {
+          errorMessage = "Your session has expired. Please log in again.";
+        } else {
+          errorMessage = `Error: ${err.detail}`;
+        }
+      }
+
+      appendStreamError(errorMessage, trimmed);
+    } finally {
+      if (activeStreamAbortRef.current === streamController) {
+        activeStreamAbortRef.current = null;
+      }
+      streamInFlightRef.current = false;
+    }
+  }, [appendStreamError, document.id, handleSessionExpired, markStreamStopped, updateStreamingAssistant]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      activeStreamAbortRef.current?.abort();
+      streamInFlightRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const loadHistory = async () => {
+      try {
+        setLoadingHistory(true);
+        const response = await chatService.getMessages(document.id);
+
+        const loadedMessages: ChatMessage[] = response.messages.map((msg) => ({
+          role: msg.role,
+          content: msg.content,
+          sources: msg.sources,
+          pipeline_meta: msg.pipeline_meta,
+        }));
+        setMessages(loadedMessages);
+      } catch (err) {
+        if (err instanceof SessionExpiredError) {
+          handleSessionExpired();
+          return;
+        }
+        console.error("Failed to load message history:", err);
+      } finally {
+        setLoadingHistory(false);
+      }
+    };
+
+    void loadHistory();
+  }, [document.id, handleSessionExpired]);
+
+  return {
+    messages,
+    loadingHistory,
+    isStreaming,
+    submitQuery,
+    stopActiveStream,
+  };
+}


### PR DESCRIPTION
## Summary
- Extracted chat orchestration and streaming lifecycle out of `ChatWindow` into `frontend/lib/hooks/useChatState.ts`.
- Updated `frontend/app/components/dashboard/ChatWindow.tsx` to delegate message loading, stream submit/stop, and session-expired callbacks to the hook.
- Shifted component streaming tests to mock `chatService` directly and added focused hook coverage for history/session-expired and stream stop/retry behavior.
- Maintains current UX behavior for citations, debug info, stop, and retry while reducing component coupling.

## Files changed
- `frontend/lib/hooks/useChatState.ts` (new)
- `frontend/lib/hooks/__tests__/useChatState.test.tsx` (new)
- `frontend/app/components/dashboard/ChatWindow.tsx`
- `frontend/app/components/dashboard/__tests__/ChatWindow.streaming.test.tsx`

## Acceptance Criteria
- [x] Chat orchestration logic is hook-owned and unit-testable.
- [x] `ChatWindow` no longer performs direct message/stream API orchestration.
- [x] Streaming token/source/meta/done/error behavior is preserved.
- [x] Stop/retry behavior is preserved.
- [x] Session-expired paths are handled via callback.
- [x] Regression coverage includes history load and stream pathways.

## Verification
```bash
cd frontend
npm test -- app/components/dashboard/__tests__/ChatWindow.streaming.test.tsx lib/hooks/__tests__/useChatState.test.tsx
npx tsc --noEmit
npm run build
```

## Notes
- `npm run build` is expected to fail only in this restricted environment due external Google Fonts fetch from `next/font` in a build-time network-dependent step.

Closes #148
