### PR TITLE
Task #155: Frontend lint blockers cleanup

### DIFF
--- a/frontend/lib/__tests__/api.auth.test.ts
+++ b/frontend/lib/__tests__/api.auth.test.ts
@@ -92,7 +92,8 @@ describe("apiRequest auth refresh contract", () => {
     const refreshResult = deferred<Response>();
     let documentRequestCount = 0;
 
-    const fetchMock = vi.fn((input: RequestInfo | URL, _init?: RequestInit) => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      void init;
       const url = String(input);
 
       if (url === "http://localhost:8000/api/documents/") {


### PR DESCRIPTION
## Summary
- Fix frontend verification blocker in `frontend/lib/__tests__/api.auth.test.ts` by keeping the optional `fetch` init arg typed and explicitly consumed.
- Preserve existing test behavior and assertions.

## Verification
- `make frontend-verify`

Closes #155
