### PR TITLE
Task #105: Workspace frontend UI and cross-document chat

### DIFF
--- a/frontend/app/components/dashboard/ChatWindow.tsx
+++ b/frontend/app/components/dashboard/ChatWindow.tsx
@@ -14,10 +14,13 @@ import { useChatState } from "@/lib/hooks/useChatState";
 interface CitationTarget {
   page: number;
   snippet?: string;
+  documentId?: number;
 }
 
 interface ChatWindowProps {
-  document: Document;
+  document?: Document;
+  workspaceId?: number;
+  workspaceName?: string;
   onBack: () => void;
   onCitationClick?: (citation: CitationTarget) => void;
   onSessionExpired?: () => void;
@@ -37,10 +40,13 @@ const MEDIUM_CONFIDENCE_THRESHOLD = 0.43;
  */
 export function ChatWindow({
   document,
+  workspaceId,
+  workspaceName,
   onBack,
   onCitationClick,
   onSessionExpired,
 }: ChatWindowProps) {
+  const isWorkspaceMode = workspaceId !== undefined;
   const [input, setInput] = useState("");
   const [debugMode, setDebugMode] = useState(() => {
     if (typeof window === "undefined") return false;
@@ -49,8 +55,9 @@ export function ChatWindow({
   const [expandedSourceIndices, setExpandedSourceIndices] = useState<Set<number>>(new Set());
   const [expandedSourceCards, setExpandedSourceCards] = useState<Set<string>>(new Set());
   const scrollRef = useRef<HTMLDivElement>(null);
-  const { messages, loadingHistory, isStreaming, submitQuery, stopActiveStream } = useChatState({
+  const { messages, loadingHistory, isStreaming, canStopStream, submitQuery, stopActiveStream } = useChatState({
     document,
+    workspaceId,
     onSessionExpired,
   });
 
@@ -127,19 +134,21 @@ export function ChatWindow({
           <button
             type="button"
             onClick={onBack}
-            title="Back to Documents"
+            title={isWorkspaceMode ? "Back to Workspaces" : "Back to Documents"}
             className="text-zinc-400 hover:text-white transition-colors cursor-pointer p-1 -m-1 rounded focus:outline-none focus:ring-2 focus:ring-lapis-500 focus:ring-offset-2 focus:ring-offset-zinc-900 shrink-0"
-            aria-label="Back to Documents"
+            aria-label={isWorkspaceMode ? "Back to Workspaces" : "Back to Documents"}
           >
             <ArrowLeft size={24} strokeWidth={2} />
           </button>
           <div className="h-4 w-px bg-zinc-700 shrink-0" aria-hidden />
           <div className="min-w-0 flex-1">
             <h2 className="font-medium text-lapis-400 italic truncate text-sm sm:text-base">
-              {document.filename}
+              {isWorkspaceMode ? (workspaceName || "Workspace") : document?.filename}
             </h2>
             <p className="text-meta truncate mt-0.5">
-              Uploaded {formatDate(document.uploaded_at)}
+              {isWorkspaceMode
+                ? "Cross-document chat"
+                : `Uploaded ${document ? formatDate(document.uploaded_at) : ""}`}
             </p>
           </div>
         </div>
@@ -198,10 +207,14 @@ export function ChatWindow({
               </svg>
             </div>
             <h3 className="text-body-sm font-medium text-zinc-200 text-center">
-              Ask a question about this document
+              {isWorkspaceMode
+                ? "Ask a question across workspace documents"
+                : "Ask a question about this document"}
             </h3>
             <p className="text-meta text-center">
-              Your questions and answers will appear here.
+              {isWorkspaceMode
+                ? "Your cross-document questions and answers will appear here."
+                : "Your questions and answers will appear here."}
             </p>
             <div className="flex flex-wrap gap-2 justify-center mt-2">
               {SUGGESTED_PROMPTS.map((prompt) => (
@@ -358,6 +371,7 @@ export function ChatWindow({
                             onCitationClick({
                               page: source.page_start,
                               snippet: source.content,
+                              documentId: source.document_id,
                             });
                           }}
                           onKeyDown={(event) => {
@@ -367,6 +381,7 @@ export function ChatWindow({
                               onCitationClick({
                                 page: source.page_start,
                                 snippet: source.content,
+                                documentId: source.document_id,
                               });
                             }
                           }}
@@ -382,6 +397,11 @@ export function ChatWindow({
                             <span className="badge-sm bg-lapis-600 text-white px-2 py-0.5 rounded">
                               {idx + 1}
                             </span>
+                            {source.document_filename && (
+                              <span className="text-meta-bright">
+                                {source.document_filename}
+                              </span>
+                            )}
                             {debugMode && (
                               <span className="text-meta-bright">
                                 Similarity: {(source.similarity * 100).toFixed(1)}%
@@ -435,10 +455,14 @@ export function ChatWindow({
             type="text"
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            placeholder="Ask a question about this document..."
+            placeholder={
+              isWorkspaceMode
+                ? "Ask a question across this workspace..."
+                : "Ask a question about this document..."
+            }
             className="flex-1 bg-zinc-950 border border-zinc-700 rounded-xl px-4 py-3 text-sm text-zinc-100 focus:outline-none focus:ring-2 focus:ring-lapis-500/20 focus:border-lapis-500 transition-all placeholder-zinc-600"
           />
-          {isStreaming ? (
+          {isStreaming && canStopStream ? (
             <button
               type="button"
               onClick={stopActiveStream}
@@ -449,7 +473,7 @@ export function ChatWindow({
           ) : (
             <button
               type="submit"
-              disabled={!input.trim()}
+              disabled={!input.trim() || isStreaming}
               className="bg-lapis-600 hover:bg-lapis-500 disabled:bg-zinc-800 disabled:text-zinc-600 disabled:cursor-not-allowed text-white px-6 py-2 rounded-xl text-sm font-medium transition-all shadow-lg shadow-lapis-900/20 flex items-center cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
             >
               Send

--- a/frontend/app/components/dashboard/DocumentPicker.tsx
+++ b/frontend/app/components/dashboard/DocumentPicker.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { X } from "lucide-react";
+import type { Document } from "@/lib/api";
+
+interface DocumentPickerProps {
+  availableDocuments: Document[];
+  onAdd: (documentIds: number[]) => Promise<void>;
+  onClose: () => void;
+  maxDocuments: number;
+}
+
+export function DocumentPicker({
+  availableDocuments,
+  onAdd,
+  onClose,
+  maxDocuments,
+}: DocumentPickerProps) {
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const remainingCapacity = Math.max(maxDocuments, 0);
+  const reachedCapacity = remainingCapacity === 0;
+
+  const sortedDocuments = useMemo(
+    () => [...availableDocuments].sort((a, b) => a.filename.localeCompare(b.filename)),
+    [availableDocuments]
+  );
+
+  const toggleSelection = (documentId: number) => {
+    setSelectedIds((current) => {
+      if (current.includes(documentId)) {
+        return current.filter((id) => id !== documentId);
+      }
+      if (current.length >= remainingCapacity) return current;
+      return [...current, documentId];
+    });
+  };
+
+  const handleAdd = async () => {
+    if (selectedIds.length === 0 || submitting) return;
+    setSubmitting(true);
+    try {
+      await onAdd(selectedIds);
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="add-documents-title"
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/60 cursor-default"
+        aria-label="Close add documents dialog"
+      />
+      <div className="relative max-w-lg w-full rounded-xl border border-zinc-700 bg-zinc-900 shadow-xl">
+        <div className="flex items-center justify-between border-b border-zinc-800 px-5 py-4">
+          <div>
+            <h2 id="add-documents-title" className="text-base font-semibold text-zinc-100">
+              Add documents
+            </h2>
+            <p className="text-xs text-zinc-400 mt-1">
+              {remainingCapacity} {remainingCapacity === 1 ? "slot" : "slots"} remaining
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="max-h-80 overflow-y-auto px-5 py-4 space-y-2">
+          {reachedCapacity ? (
+            <p className="text-sm text-zinc-400">Workspace is at the 20 document limit.</p>
+          ) : sortedDocuments.length === 0 ? (
+            <p className="text-sm text-zinc-400">No completed documents available to add.</p>
+          ) : (
+            sortedDocuments.map((doc) => {
+              const selected = selectedIds.includes(doc.id);
+              const disabled = !selected && selectedIds.length >= remainingCapacity;
+              return (
+                <label
+                  key={doc.id}
+                  className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm ${
+                    selected
+                      ? "border-lapis-500/60 bg-lapis-500/10 text-zinc-100"
+                      : "border-zinc-800 bg-zinc-800/30 text-zinc-300"
+                  } ${disabled ? "opacity-50" : "cursor-pointer"}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected}
+                    disabled={disabled}
+                    onChange={() => toggleSelection(doc.id)}
+                    className="h-4 w-4 rounded border-zinc-600 bg-zinc-950 text-lapis-600 focus:ring-lapis-500"
+                  />
+                  <span className="truncate">{doc.filename}</span>
+                </label>
+              );
+            })
+          )}
+        </div>
+
+        <div className="border-t border-zinc-800 px-5 py-4 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg px-3 py-2 text-sm text-zinc-400 hover:text-zinc-200 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              void handleAdd();
+            }}
+            disabled={selectedIds.length === 0 || submitting}
+            className="rounded-lg bg-lapis-600 px-3 py-2 text-sm font-medium text-white hover:bg-lapis-500 disabled:bg-zinc-700 disabled:text-zinc-500 disabled:cursor-not-allowed cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+          >
+            {submitting ? "Adding..." : "Add selected"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/dashboard/DocumentSwitcher.tsx
+++ b/frontend/app/components/dashboard/DocumentSwitcher.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { Document } from "@/lib/api";
+
+interface DocumentSwitcherProps {
+  documents: Document[];
+  activeDocumentId: number;
+  onSwitch: (documentId: number) => void;
+}
+
+export function DocumentSwitcher({
+  documents,
+  activeDocumentId,
+  onSwitch,
+}: DocumentSwitcherProps) {
+  return (
+    <div className="mb-2 w-full">
+      <label className="sr-only" htmlFor="workspace-document-switcher">
+        Switch document
+      </label>
+      <select
+        id="workspace-document-switcher"
+        value={activeDocumentId}
+        onChange={(event) => onSwitch(Number(event.target.value))}
+        className="w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:ring-2 focus:ring-lapis-500/20 focus:border-lapis-500"
+      >
+        {documents.map((doc) => (
+          <option key={doc.id} value={doc.id}>
+            {doc.filename}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/frontend/app/components/dashboard/WorkspaceList.tsx
+++ b/frontend/app/components/dashboard/WorkspaceList.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import type { Workspace } from "@/lib/api";
+
+interface WorkspaceListProps {
+  workspaces: Workspace[];
+  onWorkspaceClick: (workspace: Workspace) => void;
+  onCreate: (name: string) => Promise<void>;
+  disabled?: boolean;
+}
+
+export function WorkspaceList({
+  workspaces,
+  onWorkspaceClick,
+  onCreate,
+  disabled = false,
+}: WorkspaceListProps) {
+  const [isCreating, setIsCreating] = useState(false);
+  const [name, setName] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  const handleCreate = async () => {
+    const trimmed = name.trim();
+    if (!trimmed || creating) return;
+
+    setCreating(true);
+    try {
+      await onCreate(trimmed);
+      setName("");
+      setIsCreating(false);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-section">Workspaces</h3>
+        <button
+          type="button"
+          onClick={() => setIsCreating((current) => !current)}
+          disabled={disabled}
+          className="inline-flex items-center gap-1 rounded-md border border-zinc-700 px-2.5 py-1.5 text-xs text-zinc-300 hover:text-zinc-100 hover:border-zinc-500 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Create
+        </button>
+      </div>
+
+      {isCreating && (
+        <div className="rounded-lg border border-zinc-800 bg-zinc-800/40 p-2.5 space-y-2">
+          <input
+            type="text"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            maxLength={100}
+            placeholder="Workspace name"
+            className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-lapis-500/20 focus:border-lapis-500"
+          />
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setIsCreating(false);
+                setName("");
+              }}
+              className="rounded-md px-2.5 py-1.5 text-xs text-zinc-400 hover:text-zinc-200 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                void handleCreate();
+              }}
+              disabled={!name.trim() || creating}
+              className="rounded-md bg-lapis-600 px-2.5 py-1.5 text-xs font-medium text-white hover:bg-lapis-500 disabled:bg-zinc-700 disabled:text-zinc-500 disabled:cursor-not-allowed cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+            >
+              {creating ? "Creating..." : "Create"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {workspaces.length === 0 ? (
+        <p className="text-empty text-sm">No workspaces yet. Create one to group documents.</p>
+      ) : (
+        <div className="space-y-2">
+          {workspaces.map((workspace) => (
+            <button
+              key={workspace.id}
+              type="button"
+              onClick={() => onWorkspaceClick(workspace)}
+              className="w-full rounded-lg border border-zinc-800 bg-zinc-800/30 p-3 text-left hover:border-lapis-500/40 hover:bg-zinc-800/50 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+            >
+              <p className="text-sm font-medium text-zinc-100 truncate">{workspace.name}</p>
+              <p className="text-xs text-zinc-400 mt-1">
+                {workspace.document_count} {workspace.document_count === 1 ? "document" : "documents"}
+              </p>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/dashboard/WorkspaceSidebar.tsx
+++ b/frontend/app/components/dashboard/WorkspaceSidebar.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { ArrowLeft, Plus, X } from "lucide-react";
+import type { Document, WorkspaceDetail } from "@/lib/api";
+
+interface WorkspaceSidebarProps {
+  workspace: WorkspaceDetail;
+  activeDocumentId: number | null;
+  onDocumentClick: (doc: Document) => void;
+  onAddDocuments: () => void;
+  onRemoveDocument: (docId: number) => void;
+  onBack: () => void;
+  disabled?: boolean;
+}
+
+export function WorkspaceSidebar({
+  workspace,
+  activeDocumentId,
+  onDocumentClick,
+  onAddDocuments,
+  onRemoveDocument,
+  onBack,
+  disabled = false,
+}: WorkspaceSidebarProps) {
+  return (
+    <div className="flex flex-col h-full">
+      <div className="p-3 border-b border-zinc-800 space-y-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 rounded"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back
+        </button>
+        <h3 className="text-section truncate">{workspace.name}</h3>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-3 space-y-2">
+        {workspace.documents.length === 0 ? (
+          <p className="text-empty text-sm">No documents in this workspace yet.</p>
+        ) : (
+          workspace.documents.map((doc) => (
+            <div
+              key={doc.id}
+              className={`group flex items-center gap-2 rounded-lg border p-2 ${
+                doc.id === activeDocumentId
+                  ? "border-lapis-500/60 bg-lapis-500/10"
+                  : "border-zinc-800 bg-zinc-800/30"
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => onDocumentClick(doc)}
+                className="flex-1 min-w-0 text-left text-sm text-zinc-200 hover:text-zinc-100 truncate cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 rounded"
+                title={doc.filename}
+              >
+                {doc.filename}
+              </button>
+              <button
+                type="button"
+                onClick={() => onRemoveDocument(doc.id)}
+                disabled={disabled}
+                className="opacity-0 group-hover:opacity-100 rounded p-1 text-zinc-500 hover:text-red-400 hover:bg-red-500/10 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 transition-opacity"
+                aria-label={`Remove ${doc.filename}`}
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="p-3 border-t border-zinc-800">
+        <button
+          type="button"
+          onClick={onAddDocuments}
+          disabled={disabled}
+          className="w-full inline-flex items-center justify-center gap-1 rounded-lg bg-lapis-600 px-3 py-2 text-sm font-medium text-white hover:bg-lapis-500 disabled:bg-zinc-700 disabled:text-zinc-500 disabled:cursor-not-allowed cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+        >
+          <Plus className="h-4 w-4" />
+          Add document
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/dashboard/__tests__/ChatWindow.streaming.test.tsx
+++ b/frontend/app/components/dashboard/__tests__/ChatWindow.streaming.test.tsx
@@ -13,12 +13,16 @@ vi.mock("@/lib/services/chatService", async () => {
     chatService: {
       ...actual.chatService,
       getMessages: vi.fn(),
+      getWorkspaceMessages: vi.fn(),
+      queryWorkspace: vi.fn(),
       queryDocumentStream: vi.fn(),
     },
   };
 });
 
 const getMessagesMock = vi.mocked(chatService.getMessages);
+const getWorkspaceMessagesMock = vi.mocked(chatService.getWorkspaceMessages);
+const queryWorkspaceMock = vi.mocked(chatService.queryWorkspace);
 const queryDocumentStreamMock = vi.mocked(chatService.queryDocumentStream);
 
 interface StreamCallbacks {
@@ -43,6 +47,8 @@ const documentFixture: Document = {
 describe("ChatWindow streaming lifecycle", () => {
   beforeEach(() => {
     getMessagesMock.mockResolvedValue({ messages: [], total: 0 });
+    getWorkspaceMessagesMock.mockResolvedValue({ messages: [], total: 0 });
+    queryWorkspaceMock.mockReset();
     queryDocumentStreamMock.mockReset();
   });
 
@@ -295,6 +301,8 @@ describe("ChatWindow streaming lifecycle", () => {
               chunk_index: 2,
               page_start: 3,
               page_end: 4,
+              document_id: 15,
+              document_filename: "source.pdf",
             },
           ],
           created_at: "2026-03-02T12:02:00Z",
@@ -321,6 +329,7 @@ describe("ChatWindow streaming lifecycle", () => {
     expect(onCitationClick).toHaveBeenCalledWith({
       page: 3,
       snippet: "Cited section content for pages three and four.",
+      documentId: 15,
     });
   });
 
@@ -373,5 +382,38 @@ describe("ChatWindow streaming lifecycle", () => {
     expect(localStorage.getItem("quaero_debug_mode")).toBe("true");
     expect(screen.getByText(/confidence/)).toBeInTheDocument();
     expect(screen.getByText("Similarity: 91.0%")).toBeInTheDocument();
+  });
+
+  it("submits workspace queries through non-streaming workspace endpoint", async () => {
+    queryWorkspaceMock.mockResolvedValueOnce({
+      query: "How do these files connect?",
+      answer: "They share the same timeline.",
+      sources: [
+        {
+          chunk_id: 42,
+          content: "Timeline snippet.",
+          similarity: 0.91,
+          chunk_index: 1,
+          page_start: 2,
+          document_id: 99,
+          document_filename: "timeline.pdf",
+        },
+      ],
+    });
+
+    render(<ChatWindow workspaceId={22} workspaceName="Roadmap" onBack={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.queryByText("Loading conversation...")).not.toBeInTheDocument();
+    });
+
+    const input = screen.getByPlaceholderText("Ask a question across this workspace...");
+    fireEvent.change(input, { target: { value: "How do these files connect?" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(queryDocumentStreamMock).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(queryWorkspaceMock).toHaveBeenCalledWith(22, "How do these files connect?");
+      expect(screen.getByText("They share the same timeline.")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,10 +1,10 @@
 /**
- * Dashboard: sidebar layout. Documents in left sidebar; chat in main area.
- * Responsive: sidebar is fixed on desktop, drawer on mobile. Zinc + lapis theme.
+ * Dashboard: sidebar layout. Documents/workspaces in left sidebar; chat in main area.
+ * Responsive: sidebar is fixed on desktop, drawer on mobile.
  */
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import Link from "next/link";
@@ -13,9 +13,14 @@ import { UploadZone } from "../components/dashboard/UploadZone";
 import { DocumentList } from "../components/dashboard/DocumentList";
 import { ChatWindow } from "../components/dashboard/ChatWindow";
 import { DeleteDocumentModal } from "../components/dashboard/DeleteDocumentModal";
+import { WorkspaceList } from "../components/dashboard/WorkspaceList";
+import { WorkspaceSidebar } from "../components/dashboard/WorkspaceSidebar";
+import { DocumentSwitcher } from "../components/dashboard/DocumentSwitcher";
+import { DocumentPicker } from "../components/dashboard/DocumentPicker";
 import { useDashboardState } from "@/lib/hooks/useDashboardState";
 
 const SIDEBAR_WIDTH = "w-72";
+const MAX_DOCUMENTS_PER_WORKSPACE = 20;
 const PdfViewer = dynamic(
   () => import("../components/dashboard/PdfViewer").then((mod) => mod.PdfViewer),
   { ssr: false }
@@ -23,6 +28,7 @@ const PdfViewer = dynamic(
 
 export default function DashboardPage() {
   const router = useRouter();
+  const [documentPickerOpen, setDocumentPickerOpen] = useState(false);
   const handleSessionExpired = useCallback(() => {
     router.push("/login");
   }, [router]);
@@ -31,6 +37,11 @@ export default function DashboardPage() {
     loading,
     error,
     selectedDocument,
+    dashboardMode,
+    workspaces,
+    selectedWorkspace,
+    viewerDocumentId,
+    workspacesLoading,
     sidebarOpen,
     documentToDelete,
     deletingInProgress,
@@ -49,11 +60,43 @@ export default function DashboardPage() {
     handleDeleteDocument,
     handleConfirmDelete,
     handleCancelDelete,
+    setDashboardMode,
+    handleWorkspaceClick,
+    handleCreateWorkspace,
+    handleAddWorkspaceDocuments,
+    handleRemoveWorkspaceDocument,
+    handleViewerDocumentSwitch,
+    handleBackToWorkspaces,
     setSidebarOpen,
     setWorkspaceElement,
     setMobileTab,
     setDesktopSidebarCollapsed,
   } = useDashboardState({ onSessionExpired: handleSessionExpired });
+
+  const viewerDocument = useMemo(() => {
+    if (dashboardMode === "documents") {
+      return selectedDocument;
+    }
+
+    if (!selectedWorkspace || !viewerDocumentId) {
+      return null;
+    }
+
+    return selectedWorkspace.documents.find((doc) => doc.id === viewerDocumentId) || null;
+  }, [dashboardMode, selectedDocument, selectedWorkspace, viewerDocumentId]);
+
+  const availableWorkspaceDocuments = useMemo(() => {
+    if (!selectedWorkspace) return [];
+    const currentWorkspaceDocIds = new Set(selectedWorkspace.documents.map((doc) => doc.id));
+    return documents.filter(
+      (doc) => doc.status === "completed" && !currentWorkspaceDocIds.has(doc.id)
+    );
+  }, [documents, selectedWorkspace]);
+
+  const workspaceCapacityRemaining = Math.max(
+    MAX_DOCUMENTS_PER_WORKSPACE - (selectedWorkspace?.documents.length ?? 0),
+    0
+  );
 
   const showPdfPane = !useTabLayout || mobileTab === "pdf";
   const showChatPane = !useTabLayout || mobileTab === "chat";
@@ -61,7 +104,30 @@ export default function DashboardPage() {
   const sidebarContent = (
     <div className="flex flex-col h-full">
       <div className="flex items-center justify-between p-3 border-b border-zinc-800 xl:border-b-0">
-        <h2 className="text-section">Documents</h2>
+        <div className="inline-flex rounded-lg border border-zinc-800 bg-zinc-900 p-1">
+          <button
+            type="button"
+            onClick={() => setDashboardMode("documents")}
+            className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 ${
+              dashboardMode === "documents"
+                ? "bg-lapis-600 text-white"
+                : "text-zinc-300 hover:bg-zinc-800"
+            }`}
+          >
+            Documents
+          </button>
+          <button
+            type="button"
+            onClick={() => setDashboardMode("workspaces")}
+            className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 ${
+              dashboardMode === "workspaces"
+                ? "bg-lapis-600 text-white"
+                : "text-zinc-300 hover:bg-zinc-800"
+            }`}
+          >
+            Workspaces
+          </button>
+        </div>
         <button
           type="button"
           onClick={() => setSidebarOpen(false)}
@@ -71,27 +137,64 @@ export default function DashboardPage() {
           <X className="w-5 h-5" />
         </button>
       </div>
+
       <div className="flex-1 overflow-y-auto p-3 space-y-3">
-        <UploadZone
-          onUpload={handleUpload}
-          disabled={isDemoUser}
-          disabledReason="Create an account to upload your own documents."
-        />
-        {error && (
-          <div className="bg-red-900/20 border border-red-900/50 text-error p-3 rounded-lg text-body-sm">
-            {error}
-          </div>
-        )}
-        {loading ? (
-          <p className="text-empty">Loading...</p>
-        ) : (
-          <DocumentList
-            documents={documents}
-            onDocumentClick={handleDocumentClick}
-            onProcessDocument={handleProcessDocument}
-            onDeleteDocument={handleDeleteDocument}
-            hideDeleteActions={isDemoUser}
+        {dashboardMode === "documents" ? (
+          <>
+            <UploadZone
+              onUpload={handleUpload}
+              disabled={isDemoUser}
+              disabledReason="Create an account to upload your own documents."
+            />
+            {error && (
+              <div className="bg-red-900/20 border border-red-900/50 text-error p-3 rounded-lg text-body-sm">
+                {error}
+              </div>
+            )}
+            {loading ? (
+              <p className="text-empty">Loading...</p>
+            ) : (
+              <DocumentList
+                documents={documents}
+                onDocumentClick={handleDocumentClick}
+                onProcessDocument={handleProcessDocument}
+                onDeleteDocument={handleDeleteDocument}
+                hideDeleteActions={isDemoUser}
+              />
+            )}
+          </>
+        ) : selectedWorkspace ? (
+          <WorkspaceSidebar
+            workspace={selectedWorkspace}
+            activeDocumentId={viewerDocumentId}
+            onDocumentClick={(doc) => handleViewerDocumentSwitch(doc.id)}
+            onAddDocuments={() => setDocumentPickerOpen(true)}
+            onRemoveDocument={(docId) => {
+              void handleRemoveWorkspaceDocument(docId);
+            }}
+            onBack={handleBackToWorkspaces}
+            disabled={isDemoUser}
           />
+        ) : (
+          <>
+            {error && (
+              <div className="bg-red-900/20 border border-red-900/50 text-error p-3 rounded-lg text-body-sm">
+                {error}
+              </div>
+            )}
+            {workspacesLoading ? (
+              <p className="text-empty">Loading workspaces...</p>
+            ) : (
+              <WorkspaceList
+                workspaces={workspaces}
+                onWorkspaceClick={(workspace) => {
+                  void handleWorkspaceClick(workspace);
+                }}
+                onCreate={handleCreateWorkspace}
+                disabled={isDemoUser}
+              />
+            )}
+          </>
         )}
       </div>
     </div>
@@ -171,7 +274,16 @@ export default function DashboardPage() {
           />
         )}
 
-        {/* Main: chat or empty state */}
+        {documentPickerOpen && selectedWorkspace && (
+          <DocumentPicker
+            availableDocuments={availableWorkspaceDocuments}
+            maxDocuments={workspaceCapacityRemaining}
+            onAdd={handleAddWorkspaceDocuments}
+            onClose={() => setDocumentPickerOpen(false)}
+          />
+        )}
+
+        {/* Main area */}
         <main className="flex-1 min-w-0 min-h-0 flex flex-col p-4 xl:p-6">
           {isDemoUser && (
             <div className="mb-4 rounded-lg border border-amber-700/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
@@ -192,7 +304,27 @@ export default function DashboardPage() {
               </h2>
               <p className="text-empty">Loading your documents...</p>
             </div>
-          ) : selectedDocument ? (
+          ) : dashboardMode === "workspaces" && selectedWorkspace && selectedWorkspace.documents.length === 0 ? (
+            <div className="flex-1 flex flex-col items-center justify-center text-center px-4 max-w-md mx-auto">
+              <div className="p-4 rounded-full bg-zinc-800/50 mb-4">
+                <FileUp className="w-12 h-12 text-lapis-400" aria-hidden />
+              </div>
+              <h2 className="text-xl font-semibold text-zinc-200 mb-2">
+                Add documents to this workspace
+              </h2>
+              <p className="text-empty mb-8">
+                Add documents to start asking cross-document questions with citations.
+              </p>
+              <button
+                type="button"
+                onClick={() => setDocumentPickerOpen(true)}
+                disabled={isDemoUser}
+                className="px-4 py-2 rounded-lg bg-lapis-600 hover:bg-lapis-500 text-white text-sm font-medium disabled:bg-zinc-700 disabled:text-zinc-500 disabled:cursor-not-allowed cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+              >
+                Add documents
+              </button>
+            </div>
+          ) : (dashboardMode === "documents" && selectedDocument) || (dashboardMode === "workspaces" && selectedWorkspace && viewerDocument) ? (
             <div ref={setWorkspaceElement} className="flex-1 min-h-0 flex flex-col">
               {useTabLayout && (
                 <div className="mb-3 inline-flex w-full max-w-md self-center rounded-lg border border-zinc-800 bg-zinc-900 p-1">
@@ -227,12 +359,23 @@ export default function DashboardPage() {
                     useTabLayout ? "flex-1 max-w-5xl" : "flex-[1.15_0_56%]"
                   }`}
                 >
-                  <PdfViewer
-                    documentId={selectedDocument.id}
-                    highlightPage={highlightPage}
-                    highlightSnippet={highlightSnippet}
-                    onSessionExpired={handleSessionExpired}
-                  />
+                  <div className="w-full h-full min-h-0 flex flex-col">
+                    {dashboardMode === "workspaces" && selectedWorkspace && viewerDocumentId && (
+                      <DocumentSwitcher
+                        documents={selectedWorkspace.documents}
+                        activeDocumentId={viewerDocumentId}
+                        onSwitch={handleViewerDocumentSwitch}
+                      />
+                    )}
+                    {viewerDocument && (
+                      <PdfViewer
+                        documentId={viewerDocument.id}
+                        highlightPage={highlightPage}
+                        highlightSnippet={highlightSnippet}
+                        onSessionExpired={handleSessionExpired}
+                      />
+                    )}
+                  </div>
                 </section>
 
                 <section
@@ -240,14 +383,36 @@ export default function DashboardPage() {
                     useTabLayout ? "flex-1 max-w-5xl" : "flex-[0.95_0_44%]"
                   }`}
                 >
-                  <ChatWindow
-                    document={selectedDocument}
-                    onBack={handleBackToDocuments}
-                    onCitationClick={handleCitationClick}
-                    onSessionExpired={handleSessionExpired}
-                  />
+                  {dashboardMode === "documents" && selectedDocument ? (
+                    <ChatWindow
+                      document={selectedDocument}
+                      onBack={handleBackToDocuments}
+                      onCitationClick={handleCitationClick}
+                      onSessionExpired={handleSessionExpired}
+                    />
+                  ) : selectedWorkspace ? (
+                    <ChatWindow
+                      workspaceId={selectedWorkspace.id}
+                      workspaceName={selectedWorkspace.name}
+                      onBack={handleBackToWorkspaces}
+                      onCitationClick={handleCitationClick}
+                      onSessionExpired={handleSessionExpired}
+                    />
+                  ) : null}
                 </section>
               </div>
+            </div>
+          ) : dashboardMode === "workspaces" ? (
+            <div className="flex-1 flex flex-col items-center justify-center text-center px-4">
+              <div className="p-4 rounded-full bg-zinc-800/50 mb-4">
+                <PanelLeft className="w-10 h-10 text-lapis-400/80" />
+              </div>
+              <h2 className="text-xl font-semibold text-zinc-200 mb-2">
+                Select a workspace
+              </h2>
+              <p className="text-empty max-w-sm">
+                Choose a workspace from the sidebar to start cross-document chat.
+              </p>
             </div>
           ) : documents.length === 0 ? (
             <div className="flex-1 flex flex-col items-center justify-center text-center px-4 max-w-md mx-auto">

--- a/frontend/lib/__tests__/api.contract.test.ts
+++ b/frontend/lib/__tests__/api.contract.test.ts
@@ -12,18 +12,27 @@ describe("public api module contract", () => {
 
   it("exposes stable api method surface", () => {
     expect(Object.keys(apiModule.api).sort()).toEqual([
+      "addWorkspaceDocuments",
+      "createWorkspace",
       "deleteDocument",
+      "deleteWorkspace",
       "getCurrentUser",
       "getDocumentFile",
       "getDocumentStatus",
       "getDocuments",
       "getMessages",
+      "getWorkspace",
+      "getWorkspaceMessages",
+      "getWorkspaces",
       "login",
       "logout",
       "processDocument",
       "queryDocument",
       "queryDocumentStream",
+      "queryWorkspace",
       "register",
+      "removeWorkspaceDocument",
+      "updateWorkspace",
       "uploadDocument",
     ]);
   });

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -14,11 +14,16 @@ import type {
   QueryResponse,
   MessageListResponse,
   PipelineMeta,
+  Workspace,
+  WorkspaceDetail,
+  WorkspaceListResponse,
+  WorkspaceQueryResponse,
 } from "./api.types";
 import { getCsrfToken, saveAuthTokens } from "./api/http";
 import { authService } from "./services/authService";
 import { chatService } from "./services/chatService";
 import { documentService } from "./services/documentService";
+import { workspaceService } from "./services/workspaceService";
 
 // Re-export so components can do: import { api, Document, ApiError } from "@/lib/api"
 export { ApiError } from "./api.types";
@@ -31,6 +36,10 @@ export type {
   PipelineMeta,
   MessageResponse,
   MessageListResponse,
+  Workspace,
+  WorkspaceDetail,
+  WorkspaceListResponse,
+  WorkspaceQueryResponse,
 } from "./api.types";
 
 interface QueryStreamCallbacks {
@@ -134,5 +143,44 @@ export const api = {
 
   getMessages: async (documentId: number): Promise<MessageListResponse> => {
     return chatService.getMessages(documentId);
+  },
+
+  getWorkspaceMessages: async (workspaceId: number): Promise<MessageListResponse> => {
+    return chatService.getWorkspaceMessages(workspaceId);
+  },
+
+  queryWorkspace: async (workspaceId: number, query: string): Promise<WorkspaceQueryResponse> => {
+    return chatService.queryWorkspace(workspaceId, query);
+  },
+
+  createWorkspace: async (name: string): Promise<Workspace> => {
+    return workspaceService.createWorkspace(name);
+  },
+
+  getWorkspaces: async (): Promise<WorkspaceListResponse> => {
+    return workspaceService.getWorkspaces();
+  },
+
+  getWorkspace: async (workspaceId: number): Promise<WorkspaceDetail> => {
+    return workspaceService.getWorkspace(workspaceId);
+  },
+
+  updateWorkspace: async (workspaceId: number, name: string): Promise<Workspace> => {
+    return workspaceService.updateWorkspace(workspaceId, name);
+  },
+
+  deleteWorkspace: async (workspaceId: number): Promise<void> => {
+    await workspaceService.deleteWorkspace(workspaceId);
+  },
+
+  addWorkspaceDocuments: async (
+    workspaceId: number,
+    documentIds: number[]
+  ): Promise<WorkspaceDetail> => {
+    return workspaceService.addWorkspaceDocuments(workspaceId, documentIds);
+  },
+
+  removeWorkspaceDocument: async (workspaceId: number, documentId: number): Promise<WorkspaceDetail> => {
+    return workspaceService.removeWorkspaceDocument(workspaceId, documentId);
   },
 };

--- a/frontend/lib/api.types.ts
+++ b/frontend/lib/api.types.ts
@@ -79,6 +79,8 @@ export interface SearchResult {
   chunk_index: number;
   page_start?: number | null;
   page_end?: number | null;
+  document_id?: number;
+  document_filename?: string;
 }
 
 export interface QueryResponse {
@@ -104,7 +106,8 @@ export interface PipelineMeta {
 // Messages
 export interface MessageResponse {
   id: number;
-  document_id: number;
+  document_id?: number | null;
+  workspace_id?: number | null;
   user_id: number;
   role: "user" | "assistant";
   content: string;
@@ -116,4 +119,35 @@ export interface MessageResponse {
 export interface MessageListResponse {
   messages: MessageResponse[];
   total: number;
+}
+
+// Workspaces
+export interface Workspace {
+  id: number;
+  name: string;
+  user_id: number;
+  document_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WorkspaceListResponse {
+  workspaces: Workspace[];
+  total: number;
+}
+
+export interface WorkspaceDetail extends Workspace {
+  documents: Document[];
+}
+
+export interface WorkspaceSearchResult extends SearchResult {
+  document_id: number;
+  document_filename: string;
+}
+
+export interface WorkspaceQueryResponse {
+  query: string;
+  answer: string;
+  sources: WorkspaceSearchResult[];
+  pipeline_meta?: PipelineMeta;
 }

--- a/frontend/lib/hooks/useChatState.ts
+++ b/frontend/lib/hooks/useChatState.ts
@@ -20,7 +20,8 @@ interface QueryStreamCallbacks {
 }
 
 interface UseChatStateOptions {
-  document: Document;
+  document?: Document;
+  workspaceId?: number;
   onSessionExpired?: () => void;
 }
 
@@ -28,6 +29,7 @@ export interface UseChatStateResult {
   messages: ChatMessage[];
   loadingHistory: boolean;
   isStreaming: boolean;
+  canStopStream: boolean;
   submitQuery: (query: string) => Promise<void>;
   stopActiveStream: () => void;
 }
@@ -41,14 +43,18 @@ const isAbortError = (err: unknown): boolean => {
 
 export function useChatState({
   document,
+  workspaceId,
   onSessionExpired,
 }: UseChatStateOptions): UseChatStateResult {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loadingHistory, setLoadingHistory] = useState(true);
+  const [requestInFlight, setRequestInFlight] = useState(false);
   const activeStreamAbortRef = useRef<AbortController | null>(null);
   const streamInFlightRef = useRef(false);
   const isMountedRef = useRef(true);
-  const isStreaming = messages.some((message) => message.role === "assistant" && message.streaming);
+  const canStopStream = !!document && messages.some((message) => message.role === "assistant" && message.streaming);
+  const isStreaming = requestInFlight || messages.some((message) => message.role === "assistant" && message.streaming);
+  const contextKey = document ? `document:${document.id}` : workspaceId ? `workspace:${workspaceId}` : "none";
 
   const handleSessionExpired = useCallback(() => {
     onSessionExpired?.();
@@ -100,17 +106,111 @@ export function useChatState({
   }, [updateStreamingAssistant]);
 
   const stopActiveStream = useCallback(() => {
+    if (!document) return;
     activeStreamAbortRef.current?.abort();
-  }, []);
+  }, [document]);
 
   const submitQuery = useCallback(async (query: string) => {
     const trimmed = query.trim();
-    if (!trimmed || streamInFlightRef.current) return;
+    if (!trimmed || streamInFlightRef.current || (!document && !workspaceId)) return;
 
     streamInFlightRef.current = true;
-    const streamController = new AbortController();
-    activeStreamAbortRef.current?.abort();
-    activeStreamAbortRef.current = streamController;
+    setRequestInFlight(true);
+
+    if (document) {
+      const streamController = new AbortController();
+      activeStreamAbortRef.current?.abort();
+      activeStreamAbortRef.current = streamController;
+
+      setMessages((prev) => [
+        ...prev,
+        { role: "user", content: trimmed },
+        { role: "assistant", content: "", streaming: true },
+      ]);
+
+      const callbacks: QueryStreamCallbacks = {
+        onSources: (sources) => {
+          if (!isMountedRef.current || streamController.signal.aborted) return;
+          updateStreamingAssistant((message) => ({
+            ...message,
+            sources,
+          }));
+        },
+        onToken: (token) => {
+          if (!isMountedRef.current || streamController.signal.aborted) return;
+          updateStreamingAssistant((message) => ({
+            ...message,
+            content: `${message.content}${token}`,
+          }));
+        },
+        onMeta: (pipelineMeta) => {
+          if (!isMountedRef.current || streamController.signal.aborted) return;
+          updateStreamingAssistant((message) => ({
+            ...message,
+            pipeline_meta: pipelineMeta,
+          }));
+        },
+        onDone: () => {
+          if (!isMountedRef.current || streamController.signal.aborted) return;
+          updateStreamingAssistant((message) => ({
+            ...message,
+            streaming: false,
+          }));
+          activeStreamAbortRef.current = null;
+          streamInFlightRef.current = false;
+          setRequestInFlight(false);
+        },
+        onError: (detail) => {
+          if (!isMountedRef.current || streamController.signal.aborted) return;
+          appendStreamError(`Error: ${detail}`, trimmed);
+          activeStreamAbortRef.current = null;
+          streamInFlightRef.current = false;
+          setRequestInFlight(false);
+        },
+      };
+
+      try {
+        await chatService.queryDocumentStream(document.id, trimmed, callbacks, {
+          signal: streamController.signal,
+        });
+      } catch (err) {
+        if (isAbortError(err)) {
+          if (isMountedRef.current) {
+            markStreamStopped(trimmed);
+          }
+          streamInFlightRef.current = false;
+          setRequestInFlight(false);
+          return;
+        }
+
+        let errorMessage = "Error: Failed to get answer. Please try again.";
+
+        if (err instanceof ApiError) {
+          if (err.status === 400) {
+            errorMessage =
+              "This document hasn't been processed yet. Please process it first before asking questions.";
+          } else if (err.status === 404) {
+            errorMessage = "Document not found.";
+          } else if (err instanceof SessionExpiredError) {
+            handleSessionExpired();
+            return;
+          } else if (err.status === 401) {
+            errorMessage = "Your session has expired. Please log in again.";
+          } else {
+            errorMessage = `Error: ${err.detail}`;
+          }
+        }
+
+        appendStreamError(errorMessage, trimmed);
+      } finally {
+        if (activeStreamAbortRef.current === streamController) {
+          activeStreamAbortRef.current = null;
+        }
+        streamInFlightRef.current = false;
+        setRequestInFlight(false);
+      }
+      return;
+    }
 
     setMessages((prev) => [
       ...prev,
@@ -118,84 +218,39 @@ export function useChatState({
       { role: "assistant", content: "", streaming: true },
     ]);
 
-    const callbacks: QueryStreamCallbacks = {
-      onSources: (sources) => {
-        if (!isMountedRef.current || streamController.signal.aborted) return;
-        updateStreamingAssistant((message) => ({
-          ...message,
-          sources,
-        }));
-      },
-      onToken: (token) => {
-        if (!isMountedRef.current || streamController.signal.aborted) return;
-        updateStreamingAssistant((message) => ({
-          ...message,
-          content: `${message.content}${token}`,
-        }));
-      },
-      onMeta: (pipelineMeta) => {
-        if (!isMountedRef.current || streamController.signal.aborted) return;
-        updateStreamingAssistant((message) => ({
-          ...message,
-          pipeline_meta: pipelineMeta,
-        }));
-      },
-      onDone: () => {
-        if (!isMountedRef.current || streamController.signal.aborted) return;
-        updateStreamingAssistant((message) => ({
-          ...message,
-          streaming: false,
-        }));
-        activeStreamAbortRef.current = null;
-        streamInFlightRef.current = false;
-      },
-      onError: (detail) => {
-        if (!isMountedRef.current || streamController.signal.aborted) return;
-        appendStreamError(`Error: ${detail}`, trimmed);
-        activeStreamAbortRef.current = null;
-        streamInFlightRef.current = false;
-      },
-    };
-
     try {
-      await chatService.queryDocumentStream(document.id, trimmed, callbacks, {
-        signal: streamController.signal,
-      });
+      const response = await chatService.queryWorkspace(workspaceId!, trimmed);
+      if (!isMountedRef.current) return;
+
+      updateStreamingAssistant((message) => ({
+        ...message,
+        content: response.answer,
+        sources: response.sources,
+        pipeline_meta: response.pipeline_meta,
+        streaming: false,
+      }));
     } catch (err) {
-      if (isAbortError(err)) {
-        if (isMountedRef.current) {
-          markStreamStopped(trimmed);
-        }
-        streamInFlightRef.current = false;
+      if (err instanceof SessionExpiredError) {
+        handleSessionExpired();
         return;
       }
 
       let errorMessage = "Error: Failed to get answer. Please try again.";
-
       if (err instanceof ApiError) {
         if (err.status === 400) {
-          errorMessage =
-            "This document hasn't been processed yet. Please process it first before asking questions.";
+          errorMessage = `Error: ${err.detail}`;
         } else if (err.status === 404) {
-          errorMessage = "Document not found.";
-        } else if (err instanceof SessionExpiredError) {
-          handleSessionExpired();
-          return;
-        } else if (err.status === 401) {
-          errorMessage = "Your session has expired. Please log in again.";
+          errorMessage = "Workspace not found.";
         } else {
           errorMessage = `Error: ${err.detail}`;
         }
       }
-
       appendStreamError(errorMessage, trimmed);
     } finally {
-      if (activeStreamAbortRef.current === streamController) {
-        activeStreamAbortRef.current = null;
-      }
       streamInFlightRef.current = false;
+      setRequestInFlight(false);
     }
-  }, [appendStreamError, document.id, handleSessionExpired, markStreamStopped, updateStreamingAssistant]);
+  }, [appendStreamError, document, handleSessionExpired, markStreamStopped, updateStreamingAssistant, workspaceId]);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -208,9 +263,22 @@ export function useChatState({
 
   useEffect(() => {
     const loadHistory = async () => {
+      if (!document && !workspaceId) {
+        setMessages([]);
+        setLoadingHistory(false);
+        return;
+      }
+
+      activeStreamAbortRef.current?.abort();
+      streamInFlightRef.current = false;
+      setRequestInFlight(false);
+      setMessages([]);
+
       try {
         setLoadingHistory(true);
-        const response = await chatService.getMessages(document.id);
+        const response = document
+          ? await chatService.getMessages(document.id)
+          : await chatService.getWorkspaceMessages(workspaceId!);
 
         const loadedMessages: ChatMessage[] = response.messages.map((msg) => ({
           role: msg.role,
@@ -231,12 +299,13 @@ export function useChatState({
     };
 
     void loadHistory();
-  }, [document.id, handleSessionExpired]);
+  }, [contextKey, document, handleSessionExpired, workspaceId]);
 
   return {
     messages,
     loadingHistory,
     isStreaming,
+    canStopStream,
     submitQuery,
     stopActiveStream,
   };

--- a/frontend/lib/hooks/useDashboardState.ts
+++ b/frontend/lib/hooks/useDashboardState.ts
@@ -3,10 +3,13 @@ import {
   ApiError,
   isLoggedIn,
   type Document,
+  type Workspace,
+  type WorkspaceDetail,
   SessionExpiredError,
 } from "@/lib/api";
 import { authService } from "@/lib/services/authService";
 import { documentService } from "@/lib/services/documentService";
+import { workspaceService } from "@/lib/services/workspaceService";
 
 const SPLIT_LAYOUT_MIN_WIDTH = 1120;
 const SPLIT_LAYOUT_RESTORE_WIDTH = 1240;
@@ -19,10 +22,12 @@ const getInitialUseTabLayout = (): boolean => {
 };
 
 export type MobileTab = "pdf" | "chat";
+export type DashboardMode = "documents" | "workspaces";
 
 interface CitationTarget {
   page: number;
   snippet?: string;
+  documentId?: number;
 }
 
 interface UseDashboardStateOptions {
@@ -34,6 +39,11 @@ export interface UseDashboardStateResult {
   loading: boolean;
   error: string;
   selectedDocument: Document | null;
+  dashboardMode: DashboardMode;
+  workspaces: Workspace[];
+  selectedWorkspace: WorkspaceDetail | null;
+  viewerDocumentId: number | null;
+  workspacesLoading: boolean;
   sidebarOpen: boolean;
   documentToDelete: Document | null;
   deletingInProgress: boolean;
@@ -54,6 +64,14 @@ export interface UseDashboardStateResult {
   handleDeleteDocument: (doc: Document) => void;
   handleConfirmDelete: () => Promise<void>;
   handleCancelDelete: () => void;
+  setDashboardMode: (mode: DashboardMode) => void;
+  handleWorkspaceClick: (workspace: Workspace) => Promise<void>;
+  handleCreateWorkspace: (name: string) => Promise<void>;
+  handleDeleteWorkspace: (workspaceId: number) => Promise<void>;
+  handleAddWorkspaceDocuments: (documentIds: number[]) => Promise<void>;
+  handleRemoveWorkspaceDocument: (documentId: number) => Promise<void>;
+  handleViewerDocumentSwitch: (documentId: number) => void;
+  handleBackToWorkspaces: () => void;
   setSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setWorkspaceElement: React.Dispatch<React.SetStateAction<HTMLDivElement | null>>;
   setMobileTab: React.Dispatch<React.SetStateAction<MobileTab>>;
@@ -67,6 +85,11 @@ export function useDashboardState({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [selectedDocument, setSelectedDocument] = useState<Document | null>(null);
+  const [dashboardModeState, setDashboardModeState] = useState<DashboardMode>("documents");
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [selectedWorkspace, setSelectedWorkspace] = useState<WorkspaceDetail | null>(null);
+  const [viewerDocumentId, setViewerDocumentId] = useState<number | null>(null);
+  const [workspacesLoading, setWorkspacesLoading] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [documentToDelete, setDocumentToDelete] = useState<Document | null>(null);
   const [deletingInProgress, setDeletingInProgress] = useState(false);
@@ -110,6 +133,18 @@ export function useDashboardState({
       setDocuments(response.documents);
     } catch (err) {
       handleApiError(err, "Failed to load documents");
+    }
+  }, [handleApiError]);
+
+  const loadWorkspaces = useCallback(async () => {
+    try {
+      setWorkspacesLoading(true);
+      const response = await workspaceService.getWorkspaces();
+      setWorkspaces(response.workspaces);
+    } catch (err) {
+      handleApiError(err, "Failed to load workspaces");
+    } finally {
+      setWorkspacesLoading(false);
     }
   }, [handleApiError]);
 
@@ -303,6 +338,9 @@ export function useDashboardState({
 
   const handleDocumentClick = (document: Document) => {
     if (document.status !== "completed") return;
+    setDashboardModeState("documents");
+    setSelectedWorkspace(null);
+    setViewerDocumentId(null);
     setSelectedDocument(document);
     setHighlightPage(null);
     setHighlightSnippet(null);
@@ -317,8 +355,16 @@ export function useDashboardState({
     setSidebarOpen(true);
   };
 
-  const handleCitationClick = ({ page, snippet }: CitationTarget) => {
+  const handleCitationClick = ({ page, snippet, documentId }: CitationTarget) => {
     const nextSnippet = snippet?.trim() || null;
+
+    if (selectedWorkspace && documentId) {
+      const hasDocument = selectedWorkspace.documents.some((doc) => doc.id === documentId);
+      if (hasDocument) {
+        setViewerDocumentId(documentId);
+      }
+    }
+
     setMobileTab("pdf");
     setHighlightSnippet(nextSnippet);
     setHighlightPage((current) => {
@@ -372,11 +418,160 @@ export function useDashboardState({
     }
   };
 
+  const setDashboardMode = useCallback((mode: DashboardMode) => {
+    setError("");
+    setDashboardModeState(mode);
+
+    if (mode === "documents") {
+      setSelectedWorkspace(null);
+      setViewerDocumentId(null);
+      return;
+    }
+
+    setSelectedDocument(null);
+    setHighlightPage(null);
+    setHighlightSnippet(null);
+    setMobileTab("chat");
+    void loadWorkspaces();
+  }, [loadWorkspaces]);
+
+  const handleWorkspaceClick = useCallback(async (workspace: Workspace) => {
+    setError("");
+    try {
+      setWorkspacesLoading(true);
+      const workspaceDetail = await workspaceService.getWorkspace(workspace.id);
+      setDashboardModeState("workspaces");
+      setSelectedDocument(null);
+      setSelectedWorkspace(workspaceDetail);
+      setViewerDocumentId(workspaceDetail.documents[0]?.id ?? null);
+      setHighlightPage(null);
+      setHighlightSnippet(null);
+      setMobileTab("chat");
+      setSidebarOpen(false);
+    } catch (err) {
+      handleApiError(err, "Failed to load workspace");
+    } finally {
+      setWorkspacesLoading(false);
+    }
+  }, [handleApiError]);
+
+  const handleCreateWorkspace = useCallback(async (name: string) => {
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+
+    setError("");
+    try {
+      const workspace = await workspaceService.createWorkspace(trimmedName);
+      setWorkspaces((prev) => [workspace, ...prev]);
+    } catch (err) {
+      handleApiError(err, "Failed to create workspace");
+    }
+  }, [handleApiError]);
+
+  const handleDeleteWorkspace = useCallback(async (workspaceId: number) => {
+    setError("");
+    try {
+      await workspaceService.deleteWorkspace(workspaceId);
+      setWorkspaces((prev) => prev.filter((workspace) => workspace.id !== workspaceId));
+      setSelectedWorkspace((current) => (current?.id === workspaceId ? null : current));
+      setViewerDocumentId((current) => (selectedWorkspace?.id === workspaceId ? null : current));
+    } catch (err) {
+      handleApiError(err, "Failed to delete workspace");
+    }
+  }, [handleApiError, selectedWorkspace]);
+
+  const handleAddWorkspaceDocuments = useCallback(async (documentIds: number[]) => {
+    if (!selectedWorkspace || documentIds.length === 0) return;
+
+    setError("");
+    try {
+      const workspace = await workspaceService.addWorkspaceDocuments(
+        selectedWorkspace.id,
+        documentIds
+      );
+      setSelectedWorkspace(workspace);
+      setViewerDocumentId((current) => {
+        if (current && workspace.documents.some((doc) => doc.id === current)) {
+          return current;
+        }
+        return workspace.documents[0]?.id ?? null;
+      });
+      setWorkspaces((prev) =>
+        prev.map((item) =>
+          item.id === workspace.id
+            ? {
+              ...item,
+              name: workspace.name,
+              updated_at: workspace.updated_at,
+              document_count: workspace.document_count,
+            }
+            : item
+        )
+      );
+    } catch (err) {
+      handleApiError(err, "Failed to add documents to workspace");
+    }
+  }, [handleApiError, selectedWorkspace]);
+
+  const handleRemoveWorkspaceDocument = useCallback(async (documentId: number) => {
+    if (!selectedWorkspace) return;
+
+    setError("");
+    try {
+      const workspace = await workspaceService.removeWorkspaceDocument(
+        selectedWorkspace.id,
+        documentId
+      );
+      setSelectedWorkspace(workspace);
+      setViewerDocumentId((current) => {
+        if (!workspace.documents.length) return null;
+        if (current && workspace.documents.some((doc) => doc.id === current)) {
+          return current;
+        }
+        return workspace.documents[0].id;
+      });
+      setWorkspaces((prev) =>
+        prev.map((item) =>
+          item.id === workspace.id
+            ? {
+              ...item,
+              name: workspace.name,
+              updated_at: workspace.updated_at,
+              document_count: workspace.document_count,
+            }
+            : item
+        )
+      );
+    } catch (err) {
+      handleApiError(err, "Failed to remove document from workspace");
+    }
+  }, [handleApiError, selectedWorkspace]);
+
+  const handleViewerDocumentSwitch = useCallback((documentId: number) => {
+    setViewerDocumentId(documentId);
+    setHighlightPage(null);
+    setHighlightSnippet(null);
+  }, []);
+
+  const handleBackToWorkspaces = useCallback(() => {
+    setSelectedWorkspace(null);
+    setViewerDocumentId(null);
+    setHighlightPage(null);
+    setHighlightSnippet(null);
+    setSidebarOpen(true);
+    void loadWorkspaces();
+  }, [loadWorkspaces]);
+
   return {
     documents,
     loading,
     error,
     selectedDocument,
+    dashboardMode: dashboardModeState,
+    workspaces,
+    selectedWorkspace,
+    viewerDocumentId,
+    workspacesLoading,
     sidebarOpen,
     documentToDelete,
     deletingInProgress,
@@ -397,6 +592,14 @@ export function useDashboardState({
     handleDeleteDocument,
     handleConfirmDelete,
     handleCancelDelete,
+    setDashboardMode,
+    handleWorkspaceClick,
+    handleCreateWorkspace,
+    handleDeleteWorkspace,
+    handleAddWorkspaceDocuments,
+    handleRemoveWorkspaceDocument,
+    handleViewerDocumentSwitch,
+    handleBackToWorkspaces,
     setSidebarOpen,
     setWorkspaceElement,
     setMobileTab,

--- a/frontend/lib/services/__tests__/chatService.test.ts
+++ b/frontend/lib/services/__tests__/chatService.test.ts
@@ -44,6 +44,19 @@ describe("chatService", () => {
     expect(result).toEqual({ messages: [], total: 0 });
   });
 
+  it("loads workspace messages", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(200, { messages: [], total: 0 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await chatService.getWorkspaceMessages(7);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8000/api/workspaces/7/messages",
+      expect.objectContaining({ credentials: "include" })
+    );
+    expect(result).toEqual({ messages: [], total: 0 });
+  });
+
   it("submits a non-streaming query", async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       jsonResponse(200, {
@@ -65,6 +78,29 @@ describe("chatService", () => {
       })
     );
     expect(result.answer).toBe("Answer text");
+  });
+
+  it("submits a workspace query", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse(200, {
+        query: "What changed?",
+        answer: "Workspace answer",
+        sources: [],
+        pipeline_meta: undefined,
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await chatService.queryWorkspace(9, "What changed?");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8000/api/workspaces/9/query",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ query: "What changed?" }),
+      })
+    );
+    expect(result.answer).toBe("Workspace answer");
   });
 
   it("streams query events using provided callbacks", async () => {

--- a/frontend/lib/services/__tests__/workspaceService.test.ts
+++ b/frontend/lib/services/__tests__/workspaceService.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { workspaceService } from "@/lib/services/workspaceService";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("workspaceService", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it("loads the current user's workspace list", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse(200, { workspaces: [], total: 0 })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await workspaceService.getWorkspaces();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8000/api/workspaces/",
+      expect.objectContaining({ credentials: "include" })
+    );
+    expect(response).toEqual({ workspaces: [], total: 0 });
+  });
+
+  it("adds documents to an existing workspace", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse(200, {
+        id: 8,
+        name: "Q1 Workspace",
+        user_id: 1,
+        document_count: 1,
+        created_at: "2026-03-09T00:00:00Z",
+        updated_at: "2026-03-09T00:00:00Z",
+        documents: [
+          {
+            id: 2,
+            user_id: 1,
+            filename: "plan.pdf",
+            file_size: 100,
+            status: "completed",
+            uploaded_at: "2026-03-09T00:00:00Z",
+            processed_at: "2026-03-09T00:01:00Z",
+            error_message: null,
+          },
+        ],
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await workspaceService.addWorkspaceDocuments(8, [2]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8000/api/workspaces/8/documents",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ document_ids: [2] }),
+      })
+    );
+    expect(response.document_count).toBe(1);
+  });
+});

--- a/frontend/lib/services/chatService.ts
+++ b/frontend/lib/services/chatService.ts
@@ -1,6 +1,11 @@
 import { requestJsonWithAuth, requestResponseWithAuth } from "@/lib/api/http";
 import { ApiError } from "@/lib/api.types";
-import type { MessageListResponse, PipelineMeta, QueryResponse } from "@/lib/api.types";
+import type {
+  MessageListResponse,
+  PipelineMeta,
+  QueryResponse,
+  WorkspaceQueryResponse,
+} from "@/lib/api.types";
 
 interface QueryStreamCallbacks {
   onSources: (sources: QueryResponse["sources"]) => void;
@@ -21,8 +26,21 @@ export const chatService = {
     );
   },
 
+  getWorkspaceMessages: async (workspaceId: number): Promise<MessageListResponse> => {
+    return requestJsonWithAuth<MessageListResponse>(
+      `/api/workspaces/${workspaceId}/messages`
+    );
+  },
+
   queryDocument: async (documentId: number, query: string): Promise<QueryResponse> => {
     return requestJsonWithAuth<QueryResponse>(`/api/documents/${documentId}/query`, {
+      method: "POST",
+      body: JSON.stringify({ query }),
+    });
+  },
+
+  queryWorkspace: async (workspaceId: number, query: string): Promise<WorkspaceQueryResponse> => {
+    return requestJsonWithAuth<WorkspaceQueryResponse>(`/api/workspaces/${workspaceId}/query`, {
       method: "POST",
       body: JSON.stringify({ query }),
     });

--- a/frontend/lib/services/workspaceService.ts
+++ b/frontend/lib/services/workspaceService.ts
@@ -1,0 +1,58 @@
+import { requestJsonWithAuth } from "@/lib/api/http";
+import type {
+  Workspace,
+  WorkspaceDetail,
+  WorkspaceListResponse,
+} from "@/lib/api.types";
+
+export const workspaceService = {
+  createWorkspace: async (name: string): Promise<Workspace> => {
+    return requestJsonWithAuth<Workspace>("/api/workspaces/", {
+      method: "POST",
+      body: JSON.stringify({ name }),
+    });
+  },
+
+  getWorkspaces: async (): Promise<WorkspaceListResponse> => {
+    return requestJsonWithAuth<WorkspaceListResponse>("/api/workspaces/");
+  },
+
+  getWorkspace: async (workspaceId: number): Promise<WorkspaceDetail> => {
+    return requestJsonWithAuth<WorkspaceDetail>(`/api/workspaces/${workspaceId}`);
+  },
+
+  updateWorkspace: async (workspaceId: number, name: string): Promise<Workspace> => {
+    return requestJsonWithAuth<Workspace>(`/api/workspaces/${workspaceId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ name }),
+    });
+  },
+
+  deleteWorkspace: async (workspaceId: number): Promise<void> => {
+    await requestJsonWithAuth<{ message: string }>(`/api/workspaces/${workspaceId}`, {
+      method: "DELETE",
+    });
+  },
+
+  addWorkspaceDocuments: async (
+    workspaceId: number,
+    documentIds: number[]
+  ): Promise<WorkspaceDetail> => {
+    return requestJsonWithAuth<WorkspaceDetail>(`/api/workspaces/${workspaceId}/documents`, {
+      method: "POST",
+      body: JSON.stringify({ document_ids: documentIds }),
+    });
+  },
+
+  removeWorkspaceDocument: async (
+    workspaceId: number,
+    documentId: number
+  ): Promise<WorkspaceDetail> => {
+    return requestJsonWithAuth<WorkspaceDetail>(
+      `/api/workspaces/${workspaceId}/documents/${documentId}`,
+      {
+        method: "DELETE",
+      }
+    );
+  },
+};

--- a/task-105-workspace-frontend-pr-body.md
+++ b/task-105-workspace-frontend-pr-body.md
@@ -1,0 +1,29 @@
+## Summary
+
+Implements Task #105 workspace frontend UI end-to-end:
+
+- Adds dashboard workspace mode with a `Documents | Workspaces` sidebar toggle and workspace list/create flow.
+- Adds workspace sidebar navigation with document add/remove actions.
+- Adds workspace document switcher above the PDF pane.
+- Adds document picker modal for adding completed documents not already in a workspace.
+- Extends chat window + chat state for workspace context (`/api/workspaces/{id}/query` and `/api/workspaces/{id}/messages`) while preserving existing streaming document chat behavior.
+- Extends citation payloads with optional `documentId` so workspace citations switch the PDF viewer to the cited source document.
+- Adds workspace API types/services and extends the stable API facade with workspace methods.
+- Adds/updates frontend tests for workspace service methods, workspace chat path usage, citation payloads, and API contract surface.
+
+## Acceptance criteria
+
+- [x] Sidebar toggle switches between Documents and Workspaces modes.
+- [x] Users can create and open workspaces.
+- [x] Users can add/remove documents from a workspace via picker/sidebar actions.
+- [x] Workspace view shows PDF viewer + chat side by side with document switcher.
+- [x] Workspace chat uses workspace query + message endpoints.
+- [x] Workspace citations include source document context and can switch viewer document.
+- [x] Single-document chat mode remains functional.
+- [x] Frontend verification passed.
+
+## Verification
+
+- `make frontend-verify`
+
+Closes #105


### PR DESCRIPTION
## Summary

Implements Task #105 workspace frontend UI end-to-end:

- Adds dashboard workspace mode with a `Documents | Workspaces` sidebar toggle and workspace list/create flow.
- Adds workspace sidebar navigation with document add/remove actions.
- Adds workspace document switcher above the PDF pane.
- Adds document picker modal for adding completed documents not already in a workspace.
- Extends chat window + chat state for workspace context (`/api/workspaces/{id}/query` and `/api/workspaces/{id}/messages`) while preserving existing streaming document chat behavior.
- Extends citation payloads with optional `documentId` so workspace citations switch the PDF viewer to the cited source document.
- Adds workspace API types/services and extends the stable API facade with workspace methods.
- Adds/updates frontend tests for workspace service methods, workspace chat path usage, citation payloads, and API contract surface.

## Acceptance criteria

- [x] Sidebar toggle switches between Documents and Workspaces modes.
- [x] Users can create and open workspaces.
- [x] Users can add/remove documents from a workspace via picker/sidebar actions.
- [x] Workspace view shows PDF viewer + chat side by side with document switcher.
- [x] Workspace chat uses workspace query + message endpoints.
- [x] Workspace citations include source document context and can switch viewer document.
- [x] Single-document chat mode remains functional.
- [x] Frontend verification passed.

## Verification

- `make frontend-verify`

Closes #105
