### PR TITLE
fix(frontend): follow-up workspace mutation error handling (task #105)

### DIFF
--- a/TESTPLAN.md
+++ b/TESTPLAN.md
@@ -352,4 +352,153 @@ Test case definitions for Quaero. Tests are defined here before implementation. 
 
 ---
 
+## Feature: Workspace CRUD
+
+### Happy Path
+
+- POST /api/workspaces/ with valid name returns 201 and workspace object with `document_count: 0`
+- GET /api/workspaces/ returns only the authenticated user's workspaces with document counts
+- GET /api/workspaces/{id} returns workspace with full documents list
+- PATCH /api/workspaces/{id} with valid name returns 200 and updated workspace
+- DELETE /api/workspaces/{id} returns 200 and removes workspace
+
+### Error Cases
+
+- POST /api/workspaces/ returns 401 if not authenticated
+- POST /api/workspaces/ returns 403 for demo user
+- POST /api/workspaces/ returns 422 if name is empty
+- POST /api/workspaces/ returns 422 if name exceeds 100 characters
+- GET /api/workspaces/{id} returns 404 if workspace does not exist
+- GET /api/workspaces/{id} returns 404 if workspace belongs to another user
+- PATCH /api/workspaces/{id} returns 403 for demo user
+- PATCH /api/workspaces/{id} returns 404 for non-existent or wrong-owner workspace
+- DELETE /api/workspaces/{id} returns 403 for demo user
+- DELETE /api/workspaces/{id} returns 404 for non-existent or wrong-owner workspace
+
+### Edge Cases
+
+- Workspace name with leading/trailing whitespace (should be stored as-is or trimmed — follow existing pattern)
+- Creating multiple workspaces with the same name succeeds (names are not unique)
+- Deleting a workspace cascades deletion of associated messages
+
+### Security Cases
+
+- Rate limit: workspace CRUD at 20/hour per user
+- Cannot access another user's workspace via any endpoint
+
+---
+
+## Feature: Workspace Document Membership
+
+### Happy Path
+
+- POST /api/workspaces/{id}/documents with valid document_ids adds documents and returns updated workspace detail
+- DELETE /api/workspaces/{id}/documents/{doc_id} removes document from workspace
+- Adding a document already in the workspace is silently skipped (idempotent)
+- Only COMPLETED documents can be added to a workspace
+
+### Error Cases
+
+- POST /api/workspaces/{id}/documents returns 400 if adding would exceed MAX_DOCUMENTS_PER_WORKSPACE (20)
+- POST /api/workspaces/{id}/documents returns 403 for demo user
+- POST /api/workspaces/{id}/documents returns 404 if workspace not found or wrong owner
+- POST /api/workspaces/{id}/documents returns 404 if any document_id not found or not owned by user
+- POST /api/workspaces/{id}/documents rejects documents that are not COMPLETED (PENDING/PROCESSING/FAILED)
+- DELETE /api/workspaces/{id}/documents/{doc_id} returns 404 if document not in workspace
+
+### Edge Cases
+
+- Adding documents when workspace already has some (partial fill to limit)
+- Removing a document from workspace preserves existing workspace chat history
+- Document deleted entirely via DELETE /api/documents/{id} cascades removal from workspace_documents
+
+---
+
+## Feature: Cross-Document Query (Workspace RAG)
+
+### Happy Path
+
+- POST /api/workspaces/{id}/query returns answer with sources from multiple documents
+- Sources include `document_id` and `document_filename` for each chunk
+- Pipeline_meta includes timing and similarity fields matching single-doc query format
+- User message and assistant response are saved to messages table with `workspace_id` (not `document_id`)
+- LLM prompt includes document filename attribution in excerpt headers
+- Workspace chat includes bounded recent conversation history for follow-up questions
+
+### Error Cases
+
+- POST /api/workspaces/{id}/query returns 400 if workspace has 0 documents
+- POST /api/workspaces/{id}/query returns 404 if workspace not found or wrong owner
+- POST /api/workspaces/{id}/query returns 401 if not authenticated
+
+### Edge Cases
+
+- Workspace with a single document returns results equivalent to single-doc query
+- Query when some workspace documents have no chunks still returns results from chunked documents
+- Sources are ranked by similarity regardless of which document they come from
+
+### Security Cases
+
+- Rate limit: 10/hour shared bucket with single-document /query and /query/stream per user
+- Cannot query another user's workspace
+
+---
+
+## Feature: Workspace Chat History
+
+### Happy Path
+
+- GET /api/workspaces/{id}/messages returns all messages for a workspace ordered by created_at
+- Assistant messages include sources (with document_id and document_filename) and optional pipeline_meta
+- Messages have `workspace_id` set and `document_id` as null
+
+### Error Cases
+
+- Returns 404 if workspace not found or wrong owner
+- Returns empty list for workspace with no messages
+
+---
+
+## Feature: Workspace Frontend
+
+### Happy Path
+
+- Sidebar toggle switches between Documents and Workspaces modes
+- WorkspaceList renders workspace cards with name and document count
+- Clicking a workspace enters workspace view with PDF viewer + chat
+- Document switcher dropdown above PDF viewer lists workspace documents
+- Clicking a document in sidebar or switcher changes the PDF viewer document
+- Chat queries go to workspace query endpoint when in workspace mode
+- Workspace chat history loads and displays on workspace entry
+- Clicking a citation in workspace chat switches PDF viewer to source document and highlights page
+- Citation cards show document filename alongside page number
+
+### Error Cases
+
+- Empty workspace shows "add documents" prompt and disables chat input
+- Document removed from workspace while viewing switches viewer to next available doc
+
+### Edge Cases
+
+- Switching between Documents and Workspaces modes clears the other mode's selection
+- Mobile tab layout (PDF / Chat toggle) works in workspace mode
+- Demo user sees workspaces as read-only (create/modify/delete disabled)
+
+---
+
+## Feature: Message Schema Changes (Regression)
+
+### Happy Path
+
+- Existing single-document messages continue to work with nullable document_id (all existing rows have document_id set)
+- Single-document chat is unaffected by workspace_id column addition
+- MessageResponse includes both document_id and workspace_id fields
+
+### Edge Cases
+
+- CHECK constraint prevents creating a message with both document_id and workspace_id set
+- CHECK constraint prevents creating a message with neither document_id nor workspace_id set
+
+---
+
 _[?] marks items needing clarification or investigation before test implementation._

--- a/frontend/app/components/dashboard/DocumentPicker.tsx
+++ b/frontend/app/components/dashboard/DocumentPicker.tsx
@@ -6,7 +6,7 @@ import type { Document } from "@/lib/api";
 
 interface DocumentPickerProps {
   availableDocuments: Document[];
-  onAdd: (documentIds: number[]) => Promise<void>;
+  onAdd: (documentIds: number[]) => Promise<boolean>;
   onClose: () => void;
   maxDocuments: number;
 }
@@ -41,8 +41,10 @@ export function DocumentPicker({
     if (selectedIds.length === 0 || submitting) return;
     setSubmitting(true);
     try {
-      await onAdd(selectedIds);
-      onClose();
+      const addSucceeded = await onAdd(selectedIds);
+      if (addSucceeded) {
+        onClose();
+      }
     } finally {
       setSubmitting(false);
     }

--- a/frontend/app/dashboard/__tests__/page.test.tsx
+++ b/frontend/app/dashboard/__tests__/page.test.tsx
@@ -4,6 +4,7 @@ import DashboardPage from "@/app/dashboard/page";
 import { ApiError, SessionExpiredError, isLoggedIn, type Document } from "@/lib/api";
 import { chatService } from "@/lib/services/chatService";
 import { documentService } from "@/lib/services/documentService";
+import { workspaceService } from "@/lib/services/workspaceService";
 
 const pushMock = vi.fn();
 const routerMock = { push: pushMock };
@@ -51,8 +52,28 @@ vi.mock("@/lib/services/chatService", async () => {
     chatService: {
       ...actual.chatService,
       getMessages: vi.fn(),
+      getWorkspaceMessages: vi.fn(),
+      queryWorkspace: vi.fn(),
       queryDocument: vi.fn(),
       queryDocumentStream: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/lib/services/workspaceService", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/services/workspaceService")>(
+    "@/lib/services/workspaceService"
+  );
+  return {
+    ...actual,
+    workspaceService: {
+      ...actual.workspaceService,
+      getWorkspaces: vi.fn(),
+      getWorkspace: vi.fn(),
+      addWorkspaceDocuments: vi.fn(),
+      removeWorkspaceDocument: vi.fn(),
+      createWorkspace: vi.fn(),
+      deleteWorkspace: vi.fn(),
     },
   };
 });
@@ -65,6 +86,11 @@ const processDocumentMock = vi.mocked(documentService.processDocument);
 const getDocumentStatusMock = vi.mocked(documentService.getDocumentStatus);
 const deleteDocumentMock = vi.mocked(documentService.deleteDocument);
 const getMessagesMock = vi.mocked(chatService.getMessages);
+const getWorkspaceMessagesMock = vi.mocked(chatService.getWorkspaceMessages);
+const getWorkspacesMock = vi.mocked(workspaceService.getWorkspaces);
+const getWorkspaceMock = vi.mocked(workspaceService.getWorkspace);
+const addWorkspaceDocumentsMock = vi.mocked(workspaceService.addWorkspaceDocuments);
+const removeWorkspaceDocumentMock = vi.mocked(workspaceService.removeWorkspaceDocument);
 
 function makeDocument(
   overrides: Partial<Document> = {}
@@ -93,6 +119,25 @@ function makeUser(overrides: Partial<{ id: number; username: string; email: stri
   };
 }
 
+function makeWorkspace(overrides: Partial<{
+  id: number;
+  name: string;
+  user_id: number;
+  document_count: number;
+  created_at: string;
+  updated_at: string;
+}> = {}) {
+  return {
+    id: 11,
+    name: "Team Workspace",
+    user_id: 1,
+    document_count: 0,
+    created_at: "2026-03-01T10:00:00Z",
+    updated_at: "2026-03-01T10:00:00Z",
+    ...overrides,
+  };
+}
+
 describe("DashboardPage regression behavior", () => {
   beforeEach(() => {
     pushMock.mockReset();
@@ -104,6 +149,17 @@ describe("DashboardPage regression behavior", () => {
     getDocumentStatusMock.mockReset();
     deleteDocumentMock.mockReset();
     getMessagesMock.mockReset();
+    getWorkspaceMessagesMock.mockReset();
+    getWorkspacesMock.mockReset();
+    getWorkspaceMock.mockReset();
+    addWorkspaceDocumentsMock.mockReset();
+    removeWorkspaceDocumentMock.mockReset();
+
+    globalThis.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    })) as unknown as typeof ResizeObserver;
 
     isLoggedInMock.mockReturnValue(true);
     getDashboardContextMock.mockResolvedValue({
@@ -124,6 +180,20 @@ describe("DashboardPage regression behavior", () => {
     });
     deleteDocumentMock.mockResolvedValue({ message: "deleted" });
     getMessagesMock.mockResolvedValue({ messages: [], total: 0 });
+    getWorkspaceMessagesMock.mockResolvedValue({ messages: [], total: 0 });
+    getWorkspacesMock.mockResolvedValue({ workspaces: [], total: 0 });
+    getWorkspaceMock.mockResolvedValue({
+      ...makeWorkspace(),
+      documents: [],
+    });
+    addWorkspaceDocumentsMock.mockResolvedValue({
+      ...makeWorkspace(),
+      documents: [],
+    });
+    removeWorkspaceDocumentMock.mockResolvedValue({
+      ...makeWorkspace(),
+      documents: [],
+    });
   });
 
   it("renders loaded documents after successful fetch", async () => {
@@ -280,6 +350,73 @@ describe("DashboardPage regression behavior", () => {
     expect(screen.getByLabelText("Upload PDF")).not.toBeDisabled();
     expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
   });
+
+  it("keeps add-documents dialog open and shows workspace error when add fails", async () => {
+    const availableDoc = makeDocument({ id: 901, filename: "workspace-source.pdf" });
+    const workspace = makeWorkspace({ id: 21, name: "Roadmap", document_count: 0 });
+    getDashboardContextMock.mockResolvedValueOnce({
+      user: makeUser(),
+      documents: [availableDoc],
+    });
+    getWorkspacesMock.mockResolvedValueOnce({
+      workspaces: [workspace],
+      total: 1,
+    });
+    getWorkspaceMock.mockResolvedValueOnce({
+      ...workspace,
+      documents: [],
+    });
+    addWorkspaceDocumentsMock.mockRejectedValueOnce(new ApiError(500, "Add failed"));
+
+    render(<DashboardPage />);
+
+    await screen.findByText("workspace-source.pdf");
+    fireEvent.click(screen.getByRole("button", { name: "Workspaces" }));
+    const roadmapWorkspaceText = await screen.findByText("Roadmap");
+    fireEvent.click(roadmapWorkspaceText.closest("button") as HTMLButtonElement);
+    fireEvent.click(await screen.findByRole("button", { name: "Add documents" }));
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByLabelText("workspace-source.pdf"));
+    fireEvent.click(within(dialog).getByRole("button", { name: "Add selected" }));
+
+    await waitFor(() => {
+      expect(addWorkspaceDocumentsMock).toHaveBeenCalledWith(21, [901]);
+      expect(screen.getByText("Add failed")).toBeInTheDocument();
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+  });
+
+  it("shows workspace error banner when removing a document fails", async () => {
+    const workspaceDoc = makeDocument({ id: 777, filename: "remove-me.pdf" });
+    const workspace = makeWorkspace({ id: 22, name: "Operations", document_count: 1 });
+    getDashboardContextMock.mockResolvedValueOnce({
+      user: makeUser(),
+      documents: [workspaceDoc],
+    });
+    getWorkspacesMock.mockResolvedValueOnce({
+      workspaces: [workspace],
+      total: 1,
+    });
+    getWorkspaceMock.mockResolvedValueOnce({
+      ...workspace,
+      documents: [workspaceDoc],
+    });
+    removeWorkspaceDocumentMock.mockRejectedValueOnce(new ApiError(500, "Remove failed"));
+
+    render(<DashboardPage />);
+
+    await screen.findByText("remove-me.pdf");
+    fireEvent.click(screen.getByRole("button", { name: "Workspaces" }));
+    const operationsWorkspaceText = await screen.findByText("Operations");
+    fireEvent.click(operationsWorkspaceText.closest("button") as HTMLButtonElement);
+    fireEvent.click(await screen.findByRole("button", { name: "Remove remove-me.pdf" }));
+
+    await waitFor(() => {
+      expect(removeWorkspaceDocumentMock).toHaveBeenCalledWith(22, 777);
+      expect(screen.getByText("Remove failed")).toBeInTheDocument();
+    });
+  });
 });
 
 describe("DashboardPage layout contracts", () => {
@@ -303,6 +440,7 @@ describe("DashboardPage layout contracts", () => {
     getDashboardContextMock.mockReset();
     getDocumentsMock.mockReset();
     getMessagesMock.mockReset();
+    getWorkspacesMock.mockReset();
 
     isLoggedInMock.mockReturnValue(true);
     getDashboardContextMock.mockResolvedValue({
@@ -310,6 +448,7 @@ describe("DashboardPage layout contracts", () => {
       documents: [],
     });
     getMessagesMock.mockResolvedValue({ messages: [], total: 0 });
+    getWorkspacesMock.mockResolvedValue({ workspaces: [], total: 0 });
   });
 
   async function selectDocument() {

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -164,17 +164,24 @@ export default function DashboardPage() {
             )}
           </>
         ) : selectedWorkspace ? (
-          <WorkspaceSidebar
-            workspace={selectedWorkspace}
-            activeDocumentId={viewerDocumentId}
-            onDocumentClick={(doc) => handleViewerDocumentSwitch(doc.id)}
-            onAddDocuments={() => setDocumentPickerOpen(true)}
-            onRemoveDocument={(docId) => {
-              void handleRemoveWorkspaceDocument(docId);
-            }}
-            onBack={handleBackToWorkspaces}
-            disabled={isDemoUser}
-          />
+          <>
+            {error && (
+              <div className="bg-red-900/20 border border-red-900/50 text-error p-3 rounded-lg text-body-sm">
+                {error}
+              </div>
+            )}
+            <WorkspaceSidebar
+              workspace={selectedWorkspace}
+              activeDocumentId={viewerDocumentId}
+              onDocumentClick={(doc) => handleViewerDocumentSwitch(doc.id)}
+              onAddDocuments={() => setDocumentPickerOpen(true)}
+              onRemoveDocument={(docId) => {
+                void handleRemoveWorkspaceDocument(docId);
+              }}
+              onBack={handleBackToWorkspaces}
+              disabled={isDemoUser}
+            />
+          </>
         ) : (
           <>
             {error && (

--- a/frontend/lib/hooks/useDashboardState.ts
+++ b/frontend/lib/hooks/useDashboardState.ts
@@ -68,8 +68,8 @@ export interface UseDashboardStateResult {
   handleWorkspaceClick: (workspace: Workspace) => Promise<void>;
   handleCreateWorkspace: (name: string) => Promise<void>;
   handleDeleteWorkspace: (workspaceId: number) => Promise<void>;
-  handleAddWorkspaceDocuments: (documentIds: number[]) => Promise<void>;
-  handleRemoveWorkspaceDocument: (documentId: number) => Promise<void>;
+  handleAddWorkspaceDocuments: (documentIds: number[]) => Promise<boolean>;
+  handleRemoveWorkspaceDocument: (documentId: number) => Promise<boolean>;
   handleViewerDocumentSwitch: (documentId: number) => void;
   handleBackToWorkspaces: () => void;
   setSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -481,7 +481,7 @@ export function useDashboardState({
   }, [handleApiError, selectedWorkspace]);
 
   const handleAddWorkspaceDocuments = useCallback(async (documentIds: number[]) => {
-    if (!selectedWorkspace || documentIds.length === 0) return;
+    if (!selectedWorkspace || documentIds.length === 0) return false;
 
     setError("");
     try {
@@ -508,13 +508,15 @@ export function useDashboardState({
             : item
         )
       );
+      return true;
     } catch (err) {
       handleApiError(err, "Failed to add documents to workspace");
+      return false;
     }
   }, [handleApiError, selectedWorkspace]);
 
   const handleRemoveWorkspaceDocument = useCallback(async (documentId: number) => {
-    if (!selectedWorkspace) return;
+    if (!selectedWorkspace) return false;
 
     setError("");
     try {
@@ -542,8 +544,10 @@ export function useDashboardState({
             : item
         )
       );
+      return true;
     } catch (err) {
       handleApiError(err, "Failed to remove document from workspace");
+      return false;
     }
   }, [handleApiError, selectedWorkspace]);
 


### PR DESCRIPTION
## Summary
- keep workspace add/remove mutations from closing the picker on failed add attempts
- surface workspace mutation errors in the selected-workspace sidebar branch
- add frontend regression coverage for add-failure and remove-failure workspace flows
- align TESTPLAN workspace frontend coverage with the implemented workspace feature set

## Testing
- `cd frontend && npm test -- app/dashboard/__tests__/page.test.tsx`

## Links
- Follow-up to #162
- Refs #105
