### PR TITLE
Task #165: Add workspace delete UX in dashboard

### DIFF
--- a/frontend/app/components/dashboard/DeleteWorkspaceModal.tsx
+++ b/frontend/app/components/dashboard/DeleteWorkspaceModal.tsx
@@ -1,0 +1,59 @@
+interface DeleteWorkspaceModalProps {
+  workspaceName: string;
+  deleting: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function DeleteWorkspaceModal({
+  workspaceName,
+  deleting,
+  onConfirm,
+  onCancel,
+}: DeleteWorkspaceModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="delete-workspace-dialog-title"
+    >
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={deleting}
+        className="absolute inset-0 bg-black/60 cursor-default disabled:cursor-wait"
+        aria-label="Cancel"
+      />
+      <div className="relative bg-zinc-900 border border-zinc-700 rounded-xl shadow-xl max-w-md w-full p-6">
+        <h2
+          id="delete-workspace-dialog-title"
+          className="text-lg font-semibold text-zinc-100 mb-2"
+        >
+          Delete workspace?
+        </h2>
+        <p className="text-zinc-400 text-sm mb-6">
+          &quot;{workspaceName}&quot; will be permanently deleted. This cannot be undone.
+        </p>
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={deleting}
+            className="px-4 py-2 rounded-lg text-zinc-300 hover:text-zinc-100 hover:bg-zinc-800 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={deleting}
+            className="px-4 py-2 rounded-lg bg-red-600 hover:bg-red-500 text-white font-medium transition-colors cursor-pointer disabled:opacity-70 disabled:cursor-wait"
+          >
+            {deleting ? "Deleting..." : "Delete"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/dashboard/WorkspaceSidebar.tsx
+++ b/frontend/app/components/dashboard/WorkspaceSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeft, Plus, X } from "lucide-react";
+import { ArrowLeft, Plus, Trash2, X } from "lucide-react";
 import type { Document, WorkspaceDetail } from "@/lib/api";
 
 interface WorkspaceSidebarProps {
@@ -8,6 +8,7 @@ interface WorkspaceSidebarProps {
   activeDocumentId: number | null;
   onDocumentClick: (doc: Document) => void;
   onAddDocuments: () => void;
+  onDeleteWorkspace: () => void;
   onRemoveDocument: (docId: number) => void;
   onBack: () => void;
   disabled?: boolean;
@@ -18,6 +19,7 @@ export function WorkspaceSidebar({
   activeDocumentId,
   onDocumentClick,
   onAddDocuments,
+  onDeleteWorkspace,
   onRemoveDocument,
   onBack,
   disabled = false,
@@ -25,14 +27,25 @@ export function WorkspaceSidebar({
   return (
     <div className="flex flex-col h-full">
       <div className="p-3 border-b border-zinc-800 space-y-2">
-        <button
-          type="button"
-          onClick={onBack}
-          className="inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 rounded"
-        >
-          <ArrowLeft className="h-3.5 w-3.5" />
-          Back
-        </button>
+        <div className="flex items-center justify-between gap-2">
+          <button
+            type="button"
+            onClick={onBack}
+            className="inline-flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 rounded"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back
+          </button>
+          <button
+            type="button"
+            onClick={onDeleteWorkspace}
+            disabled={disabled}
+            className="inline-flex items-center gap-1 rounded-md border border-red-900/60 px-2 py-1 text-xs text-red-300 hover:bg-red-500/10 hover:text-red-200 disabled:cursor-not-allowed disabled:border-zinc-700 disabled:text-zinc-500 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            Delete workspace
+          </button>
+        </div>
         <h3 className="text-section truncate">{workspace.name}</h3>
       </div>
 

--- a/frontend/app/dashboard/__tests__/page.test.tsx
+++ b/frontend/app/dashboard/__tests__/page.test.tsx
@@ -91,6 +91,7 @@ const getWorkspacesMock = vi.mocked(workspaceService.getWorkspaces);
 const getWorkspaceMock = vi.mocked(workspaceService.getWorkspace);
 const addWorkspaceDocumentsMock = vi.mocked(workspaceService.addWorkspaceDocuments);
 const removeWorkspaceDocumentMock = vi.mocked(workspaceService.removeWorkspaceDocument);
+const deleteWorkspaceMock = vi.mocked(workspaceService.deleteWorkspace);
 
 function makeDocument(
   overrides: Partial<Document> = {}
@@ -154,6 +155,7 @@ describe("DashboardPage regression behavior", () => {
     getWorkspaceMock.mockReset();
     addWorkspaceDocumentsMock.mockReset();
     removeWorkspaceDocumentMock.mockReset();
+    deleteWorkspaceMock.mockReset();
 
     globalThis.ResizeObserver = vi.fn().mockImplementation(() => ({
       observe: vi.fn(),
@@ -194,6 +196,7 @@ describe("DashboardPage regression behavior", () => {
       ...makeWorkspace(),
       documents: [],
     });
+    deleteWorkspaceMock.mockResolvedValue();
   });
 
   it("renders loaded documents after successful fetch", async () => {
@@ -416,6 +419,133 @@ describe("DashboardPage regression behavior", () => {
       expect(removeWorkspaceDocumentMock).toHaveBeenCalledWith(22, 777);
       expect(screen.getByText("Remove failed")).toBeInTheDocument();
     });
+  });
+
+  it("deletes a selected workspace after confirmation", async () => {
+    const workspaceDoc = makeDocument({ id: 851, filename: "workspace-doc.pdf" });
+    const workspace = makeWorkspace({ id: 31, name: "Planning", document_count: 1 });
+    getDashboardContextMock.mockResolvedValueOnce({
+      user: makeUser(),
+      documents: [workspaceDoc],
+    });
+    getWorkspacesMock.mockResolvedValueOnce({
+      workspaces: [workspace],
+      total: 1,
+    });
+    getWorkspaceMock.mockResolvedValueOnce({
+      ...workspace,
+      documents: [workspaceDoc],
+    });
+
+    render(<DashboardPage />);
+
+    await screen.findByText("workspace-doc.pdf");
+    fireEvent.click(screen.getByRole("button", { name: "Workspaces" }));
+    const workspaceButton = (await screen.findByText("Planning")).closest("button");
+    fireEvent.click(workspaceButton as HTMLButtonElement);
+    fireEvent.click(await screen.findByRole("button", { name: "Delete workspace" }));
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(deleteWorkspaceMock).toHaveBeenCalledWith(31);
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(screen.getByText("No workspaces yet. Create one to group documents.")).toBeInTheDocument();
+    });
+  });
+
+  it("does not delete workspace when confirmation is canceled", async () => {
+    const workspace = makeWorkspace({ id: 32, name: "Roadmap", document_count: 0 });
+    getDashboardContextMock.mockResolvedValueOnce({
+      user: makeUser(),
+      documents: [],
+    });
+    getWorkspacesMock.mockResolvedValueOnce({
+      workspaces: [workspace],
+      total: 1,
+    });
+    getWorkspaceMock.mockResolvedValueOnce({
+      ...workspace,
+      documents: [],
+    });
+
+    render(<DashboardPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Workspaces" }));
+    const workspaceButton = (await screen.findByText("Roadmap")).closest("button");
+    fireEvent.click(workspaceButton as HTMLButtonElement);
+    fireEvent.click(await screen.findByRole("button", { name: "Delete workspace" }));
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByText("Cancel"));
+
+    await waitFor(() => {
+      expect(deleteWorkspaceMock).not.toHaveBeenCalled();
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps workspace delete modal open and shows error when delete fails", async () => {
+    const workspace = makeWorkspace({ id: 33, name: "Ops", document_count: 0 });
+    getDashboardContextMock.mockResolvedValueOnce({
+      user: makeUser(),
+      documents: [],
+    });
+    getWorkspacesMock.mockResolvedValueOnce({
+      workspaces: [workspace],
+      total: 1,
+    });
+    getWorkspaceMock.mockResolvedValueOnce({
+      ...workspace,
+      documents: [],
+    });
+    deleteWorkspaceMock.mockRejectedValueOnce(new ApiError(500, "Workspace delete failed"));
+
+    render(<DashboardPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Workspaces" }));
+    const workspaceButton = (await screen.findByText("Ops")).closest("button");
+    fireEvent.click(workspaceButton as HTMLButtonElement);
+    fireEvent.click(await screen.findByRole("button", { name: "Delete workspace" }));
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(deleteWorkspaceMock).toHaveBeenCalledWith(33);
+      expect(screen.getByText("Workspace delete failed")).toBeInTheDocument();
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+  });
+
+  it("disables workspace delete control for demo users", async () => {
+    const workspace = makeWorkspace({ id: 34, name: "Demo Workspace", document_count: 0 });
+    getDashboardContextMock.mockResolvedValueOnce({
+      user: makeUser({ is_demo: true }),
+      documents: [],
+    });
+    getWorkspacesMock.mockResolvedValueOnce({
+      workspaces: [workspace],
+      total: 1,
+    });
+    getWorkspaceMock.mockResolvedValueOnce({
+      ...workspace,
+      documents: [],
+    });
+
+    render(<DashboardPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Workspaces" }));
+    const workspaceButton = (await screen.findByText("Demo Workspace")).closest("button");
+    fireEvent.click(workspaceButton as HTMLButtonElement);
+
+    const deleteButton = await screen.findByRole("button", { name: "Delete workspace" });
+    expect(deleteButton).toBeDisabled();
+    fireEvent.click(deleteButton);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(deleteWorkspaceMock).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ import { UploadZone } from "../components/dashboard/UploadZone";
 import { DocumentList } from "../components/dashboard/DocumentList";
 import { ChatWindow } from "../components/dashboard/ChatWindow";
 import { DeleteDocumentModal } from "../components/dashboard/DeleteDocumentModal";
+import { DeleteWorkspaceModal } from "../components/dashboard/DeleteWorkspaceModal";
 import { WorkspaceList } from "../components/dashboard/WorkspaceList";
 import { WorkspaceSidebar } from "../components/dashboard/WorkspaceSidebar";
 import { DocumentSwitcher } from "../components/dashboard/DocumentSwitcher";
@@ -29,6 +30,12 @@ const PdfViewer = dynamic(
 export default function DashboardPage() {
   const router = useRouter();
   const [documentPickerOpen, setDocumentPickerOpen] = useState(false);
+  const [workspaceToDelete, setWorkspaceToDelete] = useState<{
+    id: number;
+    name: string;
+    clearSelection: boolean;
+  } | null>(null);
+  const [deletingWorkspace, setDeletingWorkspace] = useState(false);
   const handleSessionExpired = useCallback(() => {
     router.push("/login");
   }, [router]);
@@ -63,6 +70,7 @@ export default function DashboardPage() {
     setDashboardMode,
     handleWorkspaceClick,
     handleCreateWorkspace,
+    handleDeleteWorkspace,
     handleAddWorkspaceDocuments,
     handleRemoveWorkspaceDocument,
     handleViewerDocumentSwitch,
@@ -72,6 +80,26 @@ export default function DashboardPage() {
     setMobileTab,
     setDesktopSidebarCollapsed,
   } = useDashboardState({ onSessionExpired: handleSessionExpired });
+
+  const handleConfirmWorkspaceDelete = useCallback(async () => {
+    if (!workspaceToDelete) return;
+
+    setDeletingWorkspace(true);
+    const deleted = await handleDeleteWorkspace(
+      workspaceToDelete.id,
+      workspaceToDelete.clearSelection
+    );
+
+    if (deleted) {
+      setWorkspaceToDelete(null);
+    }
+    setDeletingWorkspace(false);
+  }, [handleDeleteWorkspace, workspaceToDelete]);
+
+  const handleCancelWorkspaceDelete = useCallback(() => {
+    if (deletingWorkspace) return;
+    setWorkspaceToDelete(null);
+  }, [deletingWorkspace]);
 
   const viewerDocument = useMemo(() => {
     if (dashboardMode === "documents") {
@@ -175,6 +203,13 @@ export default function DashboardPage() {
               activeDocumentId={viewerDocumentId}
               onDocumentClick={(doc) => handleViewerDocumentSwitch(doc.id)}
               onAddDocuments={() => setDocumentPickerOpen(true)}
+              onDeleteWorkspace={() =>
+                setWorkspaceToDelete({
+                  id: selectedWorkspace.id,
+                  name: selectedWorkspace.name,
+                  clearSelection: true,
+                })
+              }
               onRemoveDocument={(docId) => {
                 void handleRemoveWorkspaceDocument(docId);
               }}
@@ -278,6 +313,17 @@ export default function DashboardPage() {
             deleting={deletingInProgress}
             onConfirm={handleConfirmDelete}
             onCancel={handleCancelDelete}
+          />
+        )}
+
+        {workspaceToDelete && (
+          <DeleteWorkspaceModal
+            workspaceName={workspaceToDelete.name}
+            deleting={deletingWorkspace}
+            onConfirm={() => {
+              void handleConfirmWorkspaceDelete();
+            }}
+            onCancel={handleCancelWorkspaceDelete}
           />
         )}
 

--- a/frontend/lib/hooks/useDashboardState.ts
+++ b/frontend/lib/hooks/useDashboardState.ts
@@ -67,7 +67,7 @@ export interface UseDashboardStateResult {
   setDashboardMode: (mode: DashboardMode) => void;
   handleWorkspaceClick: (workspace: Workspace) => Promise<void>;
   handleCreateWorkspace: (name: string) => Promise<void>;
-  handleDeleteWorkspace: (workspaceId: number) => Promise<void>;
+  handleDeleteWorkspace: (workspaceId: number, clearSelection?: boolean) => Promise<boolean>;
   handleAddWorkspaceDocuments: (documentIds: number[]) => Promise<boolean>;
   handleRemoveWorkspaceDocument: (documentId: number) => Promise<boolean>;
   handleViewerDocumentSwitch: (documentId: number) => void;
@@ -468,17 +468,25 @@ export function useDashboardState({
     }
   }, [handleApiError]);
 
-  const handleDeleteWorkspace = useCallback(async (workspaceId: number) => {
+  const handleDeleteWorkspace = useCallback(async (workspaceId: number, clearSelection = false) => {
     setError("");
     try {
       await workspaceService.deleteWorkspace(workspaceId);
       setWorkspaces((prev) => prev.filter((workspace) => workspace.id !== workspaceId));
-      setSelectedWorkspace((current) => (current?.id === workspaceId ? null : current));
-      setViewerDocumentId((current) => (selectedWorkspace?.id === workspaceId ? null : current));
+      if (clearSelection) {
+        setSelectedWorkspace(null);
+        setViewerDocumentId(null);
+        setHighlightPage(null);
+        setHighlightSnippet(null);
+      } else {
+        setSelectedWorkspace((current) => (current?.id === workspaceId ? null : current));
+      }
+      return true;
     } catch (err) {
       handleApiError(err, "Failed to delete workspace");
+      return false;
     }
-  }, [handleApiError, selectedWorkspace]);
+  }, [handleApiError]);
 
   const handleAddWorkspaceDocuments = useCallback(async (documentIds: number[]) => {
     if (!selectedWorkspace || documentIds.length === 0) return false;

--- a/task-165-workspace-delete-ux-pr-body.md
+++ b/task-165-workspace-delete-ux-pr-body.md
@@ -1,0 +1,25 @@
+## Summary
+
+Implements Task #165 workspace deletion UX in dashboard:
+
+- Adds a workspace delete action to the selected workspace sidebar.
+- Adds a dedicated workspace delete confirmation modal before destructive actions.
+- Wires modal confirm/cancel flow in dashboard page and keeps modal open on API failure.
+- Tightens workspace delete state updates in `useDashboardState` by removing closure-captured `selectedWorkspace` dependency and using explicit `clearSelection` behavior.
+- Disables workspace delete action for demo users.
+- Adds dashboard regression tests for workspace delete success, cancel, failure, and demo-user restriction.
+
+## Acceptance criteria
+
+- [x] Users can trigger workspace deletion from dashboard UI.
+- [x] Deletion requires explicit confirmation.
+- [x] UI state is updated correctly after delete (workspace list + selected workspace/viewer state).
+- [x] Delete handler state update pattern avoids closure-staleness risk.
+- [x] Demo users cannot delete workspaces from UI.
+- [x] Frontend tests cover delete success, cancel, and failure behavior.
+
+## Verification
+
+- `make frontend-verify`
+
+Closes #165


### PR DESCRIPTION
## Summary

Implements Task #165 workspace deletion UX in dashboard:

- Adds a workspace delete action to the selected workspace sidebar.
- Adds a dedicated workspace delete confirmation modal before destructive actions.
- Wires modal confirm/cancel flow in dashboard page and keeps modal open on API failure.
- Tightens workspace delete state updates in `useDashboardState` by removing closure-captured `selectedWorkspace` dependency and using explicit `clearSelection` behavior.
- Disables workspace delete action for demo users.
- Adds dashboard regression tests for workspace delete success, cancel, failure, and demo-user restriction.

## Acceptance criteria

- [x] Users can trigger workspace deletion from dashboard UI.
- [x] Deletion requires explicit confirmation.
- [x] UI state is updated correctly after delete (workspace list + selected workspace/viewer state).
- [x] Delete handler state update pattern avoids closure-staleness risk.
- [x] Demo users cannot delete workspaces from UI.
- [x] Frontend tests cover delete success, cancel, and failure behavior.

## Verification

- `make frontend-verify`

Closes #165
