### PR TITLE
Task #167: Add dedicated workspace component tests

### DIFF
--- a/frontend/app/components/dashboard/__tests__/DocumentSwitcher.test.tsx
+++ b/frontend/app/components/dashboard/__tests__/DocumentSwitcher.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DocumentSwitcher } from "@/app/components/dashboard/DocumentSwitcher";
+import type { Document } from "@/lib/api";
+
+function makeDocument(overrides: Partial<Document> = {}): Document {
+  return {
+    id: 1,
+    user_id: 9,
+    filename: "alpha.pdf",
+    file_size: 100,
+    status: "completed",
+    uploaded_at: "2026-03-10T00:00:00Z",
+    processed_at: "2026-03-10T00:01:00Z",
+    error_message: null,
+    ...overrides,
+  };
+}
+
+describe("DocumentSwitcher", () => {
+  it("renders options for each document", () => {
+    render(
+      <DocumentSwitcher
+        documents={[
+          makeDocument({ id: 11, filename: "alpha.pdf" }),
+          makeDocument({ id: 12, filename: "beta.pdf" }),
+        ]}
+        activeDocumentId={11}
+        onSwitch={vi.fn()}
+      />
+    );
+
+    const selector = screen.getByLabelText("Switch document");
+    expect(selector).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "alpha.pdf" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "beta.pdf" })).toBeInTheDocument();
+  });
+
+  it("emits selected document id on change", () => {
+    const onSwitch = vi.fn();
+
+    render(
+      <DocumentSwitcher
+        documents={[
+          makeDocument({ id: 11, filename: "alpha.pdf" }),
+          makeDocument({ id: 12, filename: "beta.pdf" }),
+        ]}
+        activeDocumentId={11}
+        onSwitch={onSwitch}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Switch document"), {
+      target: { value: "12" },
+    });
+
+    expect(onSwitch).toHaveBeenCalledWith(12);
+  });
+});

--- a/frontend/app/components/dashboard/__tests__/WorkspaceList.test.tsx
+++ b/frontend/app/components/dashboard/__tests__/WorkspaceList.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { WorkspaceList } from "@/app/components/dashboard/WorkspaceList";
+import type { Workspace } from "@/lib/api";
+
+function makeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
+  return {
+    id: 1,
+    name: "Workspace A",
+    user_id: 10,
+    document_count: 2,
+    created_at: "2026-03-10T00:00:00Z",
+    updated_at: "2026-03-10T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("WorkspaceList", () => {
+  it("renders empty state when there are no workspaces", () => {
+    render(
+      <WorkspaceList
+        workspaces={[]}
+        onWorkspaceClick={vi.fn()}
+        onCreate={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(
+      screen.getByText("No workspaces yet. Create one to group documents.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders workspace rows with document counts and handles workspace click", () => {
+    const onWorkspaceClick = vi.fn();
+    const firstWorkspace = makeWorkspace({ id: 5, name: "Alpha", document_count: 1 });
+    const secondWorkspace = makeWorkspace({ id: 6, name: "Beta", document_count: 3 });
+
+    render(
+      <WorkspaceList
+        workspaces={[firstWorkspace, secondWorkspace]}
+        onWorkspaceClick={onWorkspaceClick}
+        onCreate={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByText("1 document")).toBeInTheDocument();
+    expect(screen.getByText("3 documents")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Beta 3 documents" }));
+    expect(onWorkspaceClick).toHaveBeenCalledWith(secondWorkspace);
+  });
+
+  it("runs create flow callback with trimmed name and closes the form", async () => {
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <WorkspaceList
+        workspaces={[]}
+        onWorkspaceClick={vi.fn()}
+        onCreate={onCreate}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    fireEvent.change(screen.getByPlaceholderText("Workspace name"), {
+      target: { value: "   New Team Workspace   " },
+    });
+    const createForm = screen.getByPlaceholderText("Workspace name").closest("div");
+    expect(createForm).toBeTruthy();
+    fireEvent.click(within(createForm as HTMLElement).getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith("New Team Workspace");
+    });
+    expect(screen.queryByPlaceholderText("Workspace name")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/app/components/dashboard/__tests__/WorkspaceSidebar.test.tsx
+++ b/frontend/app/components/dashboard/__tests__/WorkspaceSidebar.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { WorkspaceSidebar } from "@/app/components/dashboard/WorkspaceSidebar";
+import type { Document, WorkspaceDetail } from "@/lib/api";
+
+function makeDocument(overrides: Partial<Document> = {}): Document {
+  return {
+    id: 1,
+    user_id: 7,
+    filename: "alpha.pdf",
+    file_size: 1000,
+    status: "completed",
+    uploaded_at: "2026-03-10T00:00:00Z",
+    processed_at: "2026-03-10T00:01:00Z",
+    error_message: null,
+    ...overrides,
+  };
+}
+
+function makeWorkspace(overrides: Partial<WorkspaceDetail> = {}): WorkspaceDetail {
+  return {
+    id: 50,
+    name: "Q1 Workspace",
+    user_id: 7,
+    document_count: 2,
+    created_at: "2026-03-10T00:00:00Z",
+    updated_at: "2026-03-10T00:00:00Z",
+    documents: [
+      makeDocument({ id: 21, filename: "alpha.pdf" }),
+      makeDocument({ id: 22, filename: "beta.pdf" }),
+    ],
+    ...overrides,
+  };
+}
+
+describe("WorkspaceSidebar", () => {
+  it("renders workspace documents and active document style", () => {
+    render(
+      <WorkspaceSidebar
+        workspace={makeWorkspace()}
+        activeDocumentId={22}
+        onDocumentClick={vi.fn()}
+        onAddDocuments={vi.fn()}
+        onDeleteWorkspace={vi.fn()}
+        onRemoveDocument={vi.fn()}
+        onBack={vi.fn()}
+      />
+    );
+
+    const activeDocButton = screen.getByRole("button", { name: "beta.pdf" });
+    const inactiveDocButton = screen.getByRole("button", { name: "alpha.pdf" });
+    const activeRow = activeDocButton.closest("div.group");
+    const inactiveRow = inactiveDocButton.closest("div.group");
+
+    expect(activeRow?.className).toContain("border-lapis-500/60");
+    expect(inactiveRow?.className).toContain("border-zinc-800");
+  });
+
+  it("runs document and workspace callbacks", () => {
+    const workspace = makeWorkspace();
+    const onDocumentClick = vi.fn();
+    const onAddDocuments = vi.fn();
+    const onRemoveDocument = vi.fn();
+
+    render(
+      <WorkspaceSidebar
+        workspace={workspace}
+        activeDocumentId={null}
+        onDocumentClick={onDocumentClick}
+        onAddDocuments={onAddDocuments}
+        onDeleteWorkspace={vi.fn()}
+        onRemoveDocument={onRemoveDocument}
+        onBack={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "alpha.pdf" }));
+    expect(onDocumentClick).toHaveBeenCalledWith(workspace.documents[0]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove beta.pdf" }));
+    expect(onRemoveDocument).toHaveBeenCalledWith(22);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add document" }));
+    expect(onAddDocuments).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated `WorkspaceList` component tests for empty state, list rendering/counts, and create callback flow
- add dedicated `WorkspaceSidebar` component tests for document rendering, active state class, and add/remove/click callbacks
- add dedicated `DocumentSwitcher` component tests for option rendering and `documentId` emission on select change

## Verification
- `make frontend-verify`

Closes #167
