### PR TITLE
Task #113: Fix dashboard processing indicators and dismissible error banners

### DIFF
--- a/frontend/app/components/dashboard/DocumentList.tsx
+++ b/frontend/app/components/dashboard/DocumentList.tsx
@@ -32,7 +32,7 @@ function StatusIcon({
   processing: boolean;
 }) {
   const base = "w-4 h-4 shrink-0";
-  if (processing)
+  if (processing || status === "pending" || status === "processing")
     return (
       <Loader2
         className={`${base} text-yellow-400 animate-spin`}
@@ -51,17 +51,8 @@ function StatusIcon({
       return (
         <XCircle className={`${base} text-red-400`} aria-label="Failed" />
       );
-    case "pending":
-      return (
-        <Clock className={`${base} text-zinc-400`} aria-label="Pending" />
-      );
     default:
-      return (
-        <Loader2
-          className={`${base} text-yellow-400 animate-spin`}
-          aria-label="Processing"
-        />
-      );
+      return <Clock className={`${base} text-zinc-400`} aria-label="Pending" />;
   }
 }
 
@@ -75,8 +66,7 @@ export function DocumentList({
   const [processingId, setProcessingId] = useState<number | null>(null);
 
   const isClickable = (doc: Document) => doc.status === "completed";
-  const canQueue = (doc: Document) =>
-    doc.status === "pending" || doc.status === "failed";
+  const canQueue = (doc: Document) => doc.status === "failed";
 
   const handleProcess = async (e: React.MouseEvent, doc: Document) => {
     e.stopPropagation();
@@ -170,7 +160,7 @@ export function DocumentList({
             <div className="flex items-center gap-2 mt-1.5 text-meta-bright">
               <StatusIcon
                 status={doc.status}
-                processing={doc.status === "processing" || isProcessing}
+                processing={isProcessing}
               />
               <span>{formatFileSize(doc.file_size)}</span>
               {doc.status === "failed" && doc.error_message && (

--- a/frontend/app/components/dashboard/__tests__/DocumentList.test.tsx
+++ b/frontend/app/components/dashboard/__tests__/DocumentList.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DocumentList } from "@/app/components/dashboard/DocumentList";
+import type { Document } from "@/lib/api";
+
+function makeDocument(overrides: Partial<Document> = {}): Document {
+  return {
+    id: 1,
+    user_id: 1,
+    filename: "alpha.pdf",
+    file_size: 2048,
+    status: "completed",
+    uploaded_at: "2026-03-10T00:00:00Z",
+    processed_at: "2026-03-10T00:01:00Z",
+    error_message: null,
+    ...overrides,
+  };
+}
+
+describe("DocumentList", () => {
+  it("renders row status icons for queued, processing, completed, and failed states", () => {
+    render(
+      <DocumentList
+        documents={[
+          makeDocument({ id: 11, status: "pending", filename: "queued.pdf" }),
+          makeDocument({ id: 12, status: "processing", filename: "processing.pdf" }),
+          makeDocument({ id: 13, status: "completed", filename: "processed.pdf" }),
+          makeDocument({ id: 14, status: "failed", filename: "failed.pdf", error_message: "Boom" }),
+        ]}
+        onDocumentClick={vi.fn()}
+        onProcessDocument={vi.fn().mockResolvedValue(undefined)}
+        onDeleteDocument={vi.fn()}
+        hideDeleteActions
+      />
+    );
+
+    expect(screen.getAllByLabelText("Processing")).toHaveLength(2);
+    expect(screen.getByLabelText("Completed")).toBeInTheDocument();
+    expect(screen.getByLabelText("Failed")).toBeInTheDocument();
+  });
+
+  it("hides process action for queued/processing rows and keeps retry for failed rows", async () => {
+    const onProcessDocument = vi.fn().mockResolvedValue(undefined);
+    const failedDoc = makeDocument({
+      id: 22,
+      status: "failed",
+      filename: "needs-retry.pdf",
+      error_message: "Retry me",
+    });
+
+    render(
+      <DocumentList
+        documents={[
+          makeDocument({ id: 20, status: "pending", filename: "queued.pdf" }),
+          makeDocument({ id: 21, status: "processing", filename: "processing.pdf" }),
+          failedDoc,
+        ]}
+        onDocumentClick={vi.fn()}
+        onProcessDocument={onProcessDocument}
+        onDeleteDocument={vi.fn()}
+        hideDeleteActions
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: "Process" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(onProcessDocument).toHaveBeenCalledWith(failedDoc);
+    });
+  });
+});

--- a/frontend/app/dashboard/__tests__/page.test.tsx
+++ b/frontend/app/dashboard/__tests__/page.test.tsx
@@ -269,11 +269,12 @@ describe("DashboardPage regression behavior", () => {
     });
   });
 
-  it("queues document processing and reloads the list", async () => {
-    const pendingDoc = makeDocument({
+  it("retries failed document processing and reloads the list", async () => {
+    const failedDoc = makeDocument({
       id: 201,
-      status: "pending",
+      status: "failed",
       processed_at: null,
+      error_message: "Queue failed",
     });
     const processingDoc = makeDocument({
       id: 201,
@@ -283,19 +284,47 @@ describe("DashboardPage regression behavior", () => {
 
     getDashboardContextMock.mockResolvedValueOnce({
       user: makeUser(),
-      documents: [pendingDoc],
+      documents: [failedDoc],
     });
     getDocumentsMock.mockResolvedValueOnce({ documents: [processingDoc], total: 1 });
 
     render(<DashboardPage />);
 
     await screen.findByText("alpha.pdf");
-    fireEvent.click(screen.getByRole("button", { name: "Process" }));
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
 
     await waitFor(() => {
       expect(processDocumentMock).toHaveBeenCalledWith(201);
       expect(getDocumentsMock).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("dismisses sidebar errors and allows later errors to render", async () => {
+    const failedDoc = makeDocument({
+      id: 202,
+      status: "failed",
+      processed_at: null,
+      error_message: "Queue failed",
+    });
+    getDashboardContextMock.mockResolvedValueOnce({
+      user: makeUser(),
+      documents: [failedDoc],
+    });
+    processDocumentMock
+      .mockRejectedValueOnce(new ApiError(500, "First queue failure"))
+      .mockRejectedValueOnce(new ApiError(500, "Second queue failure"));
+
+    render(<DashboardPage />);
+
+    await screen.findByText("alpha.pdf");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(await screen.findByText("First queue failure")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss error" }));
+    expect(screen.queryByText("First queue failure")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByText("Second queue failure")).toBeInTheDocument();
   });
 
   it("deletes a document and reloads the list", async () => {

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -58,6 +58,7 @@ export default function DashboardPage() {
     useTabLayout,
     desktopSidebarCollapsed,
     isDemoUser,
+    clearError,
     handleUpload,
     handleLogout,
     handleDocumentClick,
@@ -128,6 +129,19 @@ export default function DashboardPage() {
 
   const showPdfPane = !useTabLayout || mobileTab === "pdf";
   const showChatPane = !useTabLayout || mobileTab === "chat";
+  const errorBanner = error ? (
+    <div className="bg-red-900/20 border border-red-900/50 text-error p-3 rounded-lg text-body-sm flex items-start gap-2">
+      <p className="flex-1 min-w-0">{error}</p>
+      <button
+        type="button"
+        onClick={clearError}
+        className="p-0.5 rounded text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800/80 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-lapis-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+        aria-label="Dismiss error"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  ) : null;
 
   const sidebarContent = (
     <div className="flex flex-col h-full">
@@ -174,11 +188,7 @@ export default function DashboardPage() {
               disabled={isDemoUser}
               disabledReason="Create an account to upload your own documents."
             />
-            {error && (
-              <div className="bg-red-900/20 border border-red-900/50 text-error p-3 rounded-lg text-body-sm">
-                {error}
-              </div>
-            )}
+            {errorBanner}
             {loading ? (
               <p className="text-empty">Loading...</p>
             ) : (
@@ -193,11 +203,7 @@ export default function DashboardPage() {
           </>
         ) : selectedWorkspace ? (
           <>
-            {error && (
-              <div className="bg-red-900/20 border border-red-900/50 text-error p-3 rounded-lg text-body-sm">
-                {error}
-              </div>
-            )}
+            {errorBanner}
             <WorkspaceSidebar
               workspace={selectedWorkspace}
               activeDocumentId={viewerDocumentId}
@@ -219,11 +225,7 @@ export default function DashboardPage() {
           </>
         ) : (
           <>
-            {error && (
-              <div className="bg-red-900/20 border border-red-900/50 text-error p-3 rounded-lg text-body-sm">
-                {error}
-              </div>
-            )}
+            {errorBanner}
             {workspacesLoading ? (
               <p className="text-empty">Loading workspaces...</p>
             ) : (

--- a/frontend/lib/hooks/useDashboardState.ts
+++ b/frontend/lib/hooks/useDashboardState.ts
@@ -55,6 +55,7 @@ export interface UseDashboardStateResult {
   workspaceElement: HTMLDivElement | null;
   isDemoUser: boolean;
   hasActiveDocuments: boolean;
+  clearError: () => void;
   handleUpload: (file: File) => Promise<void>;
   handleLogout: () => Promise<void>;
   handleDocumentClick: (document: Document) => void;
@@ -336,6 +337,10 @@ export function useDashboardState({
     handleSessionExpired();
   };
 
+  const clearError = useCallback(() => {
+    setError("");
+  }, []);
+
   const handleDocumentClick = (document: Document) => {
     if (document.status !== "completed") return;
     setDashboardModeState("documents");
@@ -595,6 +600,7 @@ export function useDashboardState({
     workspaceElement,
     isDemoUser,
     hasActiveDocuments,
+    clearError,
     handleUpload,
     handleLogout,
     handleDocumentClick,


### PR DESCRIPTION
## Summary
- treat `pending` and `processing` document rows as active in-progress states with the same spinner UI
- hide process/play action for queued and processing rows, and keep retry available for failed rows
- add a dismiss (`X`) control to dashboard error banners that clears local UI error state immediately
- add frontend tests for row-state rendering and dismissible error banner behavior

## Verification
- `make frontend-verify`

Closes #113
