### PR TITLE
Task #193: Add minimal manual-dispatch Terraform ops workflow

### DIFF
--- a/.github/workflows/infra-terraform-ops.yml
+++ b/.github/workflows/infra-terraform-ops.yml
@@ -46,13 +46,26 @@ jobs:
   terraform-plan:
     if: ${{ inputs.action == 'plan' }}
     runs-on: ubuntu-latest
+    env:
+      INPUT_ACTION: ${{ inputs.action }}
+      INPUT_TARGET_REF: ${{ inputs.target_ref }}
+      INPUT_TF_DIR: ${{ inputs.tf_dir }}
+      INPUT_TFVARS_PATH: ${{ inputs.tfvars_path }}
+      INPUT_DESTROY_CONFIRM: ${{ inputs.destroy_confirm }}
 
     steps:
+      - name: Validate dispatch input allowlist
+        run: |
+          set -euo pipefail
+          [ "${INPUT_TARGET_REF}" = "main" ] || { echo "target_ref must be main"; exit 1; }
+          [ "${INPUT_TF_DIR}" = "infra/terraform" ] || { echo "tf_dir must be infra/terraform"; exit 1; }
+          [ "${INPUT_TFVARS_PATH}" = "envs/prod.tfvars" ] || { echo "tfvars_path must be envs/prod.tfvars"; exit 1; }
+
       - name: Enforce protected main for plan
         run: |
           set -euo pipefail
           [ "${GITHUB_REF}" = "refs/heads/main" ] || { echo "Plan must be dispatched from main. Current ref: ${GITHUB_REF}"; exit 1; }
-          [ "${{ inputs.target_ref }}" = "main" ] || { echo "Plan requires target_ref=main."; exit 1; }
+          [ "${INPUT_TARGET_REF}" = "main" ] || { echo "Plan requires target_ref=main."; exit 1; }
 
       - name: Checkout main
         uses: actions/checkout@v4
@@ -83,7 +96,7 @@ jobs:
         id: decode_tfvars
         run: |
           set -euo pipefail
-          tfvars_file="${{ inputs.tf_dir }}/${{ inputs.tfvars_path }}"
+          tfvars_file="${INPUT_TF_DIR}/${INPUT_TFVARS_PATH}"
           mkdir -p "$(dirname "${tfvars_file}")"
           umask 077
           printf '%s' "${{ secrets.TFVARS_PROD_B64 }}" | base64 --decode > "${tfvars_file}"
@@ -93,13 +106,13 @@ jobs:
       - name: Terraform init and validate
         run: |
           set -euo pipefail
-          terraform -chdir="${{ inputs.tf_dir }}" init -input=false
-          terraform -chdir="${{ inputs.tf_dir }}" validate
+          terraform -chdir="${INPUT_TF_DIR}" init -input=false
+          terraform -chdir="${INPUT_TF_DIR}" validate
 
       - name: Terraform plan
         run: |
           set -euo pipefail
-          terraform -chdir="${{ inputs.tf_dir }}" plan -input=false -var-file="${{ inputs.tfvars_path }}"
+          terraform -chdir="${INPUT_TF_DIR}" plan -input=false -var-file="${INPUT_TFVARS_PATH}"
 
       - name: Summarize run
         if: always()
@@ -107,40 +120,59 @@ jobs:
           {
             echo "## Infra Terraform Ops"
             echo
-            echo "- Action: \`${{ inputs.action }}\`"
-            echo "- Ref: \`${{ inputs.target_ref }}\`"
-            echo "- Terraform dir: \`${{ inputs.tf_dir }}\`"
-            echo "- tfvars path: \`${{ inputs.tfvars_path }}\`"
+            echo "- Action: \`${INPUT_ACTION}\`"
+            echo "- Ref: \`${INPUT_TARGET_REF}\`"
+            echo "- Terraform dir: \`${INPUT_TF_DIR}\`"
+            echo "- tfvars path: \`${INPUT_TFVARS_PATH}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Cleanup sensitive files
         if: always()
         run: |
-          tfvars_file="${{ inputs.tf_dir }}/${{ inputs.tfvars_path }}"
-          rm -f "${tfvars_file}" "${{ inputs.tf_dir }}/tfplan.binary" "${{ inputs.tf_dir }}/tfplan.destroy.binary"
+          tfvars_file="${INPUT_TF_DIR}/${INPUT_TFVARS_PATH}"
+          rm -f "${tfvars_file}" "${INPUT_TF_DIR}/tfplan.binary" "${INPUT_TF_DIR}/tfplan.destroy.binary"
 
   terraform-mutate-guard:
     if: ${{ inputs.action == 'apply' || inputs.action == 'destroy' }}
     runs-on: ubuntu-latest
+    env:
+      INPUT_ACTION: ${{ inputs.action }}
+      INPUT_TARGET_REF: ${{ inputs.target_ref }}
+      INPUT_TF_DIR: ${{ inputs.tf_dir }}
+      INPUT_TFVARS_PATH: ${{ inputs.tfvars_path }}
+      INPUT_DESTROY_CONFIRM: ${{ inputs.destroy_confirm }}
 
     steps:
+      - name: Validate dispatch input allowlist
+        run: |
+          set -euo pipefail
+          [ "${INPUT_TARGET_REF}" = "main" ] || { echo "target_ref must be main"; exit 1; }
+          [ "${INPUT_TF_DIR}" = "infra/terraform" ] || { echo "tf_dir must be infra/terraform"; exit 1; }
+          [ "${INPUT_TFVARS_PATH}" = "envs/prod.tfvars" ] || { echo "tfvars_path must be envs/prod.tfvars"; exit 1; }
+
       - name: Enforce protected main for mutating actions
         run: |
           set -euo pipefail
           [ "${GITHUB_REF}" = "refs/heads/main" ] || { echo "Mutating actions must be dispatched from main. Current ref: ${GITHUB_REF}"; exit 1; }
-          [ "${{ inputs.target_ref }}" = "main" ] || { echo "Mutating actions require target_ref=main."; exit 1; }
+          [ "${INPUT_TARGET_REF}" = "main" ] || { echo "Mutating actions require target_ref=main."; exit 1; }
 
       - name: Guard destroy confirmation
         if: ${{ inputs.action == 'destroy' }}
         run: |
           set -euo pipefail
-          [ "${{ inputs.destroy_confirm }}" = "DESTROY_PROD" ] || { echo "Destroy blocked: destroy_confirm must equal DESTROY_PROD"; exit 1; }
+          [ "${INPUT_DESTROY_CONFIRM}" = "DESTROY_PROD" ] || { echo "Destroy blocked: destroy_confirm must equal DESTROY_PROD"; exit 1; }
 
   terraform-mutate:
     if: ${{ inputs.action == 'apply' || inputs.action == 'destroy' }}
     needs: terraform-mutate-guard
     runs-on: ubuntu-latest
     environment: infra-prod
+    env:
+      INPUT_ACTION: ${{ inputs.action }}
+      INPUT_TARGET_REF: ${{ inputs.target_ref }}
+      INPUT_TF_DIR: ${{ inputs.tf_dir }}
+      INPUT_TFVARS_PATH: ${{ inputs.tfvars_path }}
+      INPUT_DESTROY_CONFIRM: ${{ inputs.destroy_confirm }}
 
     steps:
       - name: Checkout main
@@ -172,7 +204,7 @@ jobs:
         id: decode_tfvars
         run: |
           set -euo pipefail
-          tfvars_file="${{ inputs.tf_dir }}/${{ inputs.tfvars_path }}"
+          tfvars_file="${INPUT_TF_DIR}/${INPUT_TFVARS_PATH}"
           mkdir -p "$(dirname "${tfvars_file}")"
           umask 077
           printf '%s' "${{ secrets.TFVARS_PROD_B64 }}" | base64 --decode > "${tfvars_file}"
@@ -182,32 +214,32 @@ jobs:
       - name: Terraform init and validate
         run: |
           set -euo pipefail
-          terraform -chdir="${{ inputs.tf_dir }}" init -input=false
-          terraform -chdir="${{ inputs.tf_dir }}" validate
+          terraform -chdir="${INPUT_TF_DIR}" init -input=false
+          terraform -chdir="${INPUT_TF_DIR}" validate
 
       - name: Terraform plan for apply
         if: ${{ inputs.action == 'apply' }}
         run: |
           set -euo pipefail
-          terraform -chdir="${{ inputs.tf_dir }}" plan -input=false -var-file="${{ inputs.tfvars_path }}" -out=tfplan.binary
+          terraform -chdir="${INPUT_TF_DIR}" plan -input=false -var-file="${INPUT_TFVARS_PATH}" -out=tfplan.binary
 
       - name: Terraform plan for destroy
         if: ${{ inputs.action == 'destroy' }}
         run: |
           set -euo pipefail
-          terraform -chdir="${{ inputs.tf_dir }}" plan -destroy -input=false -var-file="${{ inputs.tfvars_path }}" -out=tfplan.destroy.binary
+          terraform -chdir="${INPUT_TF_DIR}" plan -destroy -input=false -var-file="${INPUT_TFVARS_PATH}" -out=tfplan.destroy.binary
 
       - name: Terraform apply planned apply
         if: ${{ inputs.action == 'apply' }}
         run: |
           set -euo pipefail
-          terraform -chdir="${{ inputs.tf_dir }}" apply -input=false -auto-approve tfplan.binary
+          terraform -chdir="${INPUT_TF_DIR}" apply -input=false -auto-approve tfplan.binary
 
       - name: Terraform apply planned destroy
         if: ${{ inputs.action == 'destroy' }}
         run: |
           set -euo pipefail
-          terraform -chdir="${{ inputs.tf_dir }}" apply -input=false -auto-approve tfplan.destroy.binary
+          terraform -chdir="${INPUT_TF_DIR}" apply -input=false -auto-approve tfplan.destroy.binary
 
       - name: Summarize run
         if: always()
@@ -215,17 +247,21 @@ jobs:
           {
             echo "## Infra Terraform Ops"
             echo
-            echo "- Action: \`${{ inputs.action }}\`"
-            echo "- Ref: \`${{ inputs.target_ref }}\`"
-            echo "- Terraform dir: \`${{ inputs.tf_dir }}\`"
-            echo "- tfvars path: \`${{ inputs.tfvars_path }}\`"
-            if [ "${{ inputs.action }}" = "destroy" ]; then
-              echo "- Destroy confirm provided: \`${{ inputs.destroy_confirm == 'DESTROY_PROD' }}\`"
+            echo "- Action: \`${INPUT_ACTION}\`"
+            echo "- Ref: \`${INPUT_TARGET_REF}\`"
+            echo "- Terraform dir: \`${INPUT_TF_DIR}\`"
+            echo "- tfvars path: \`${INPUT_TFVARS_PATH}\`"
+            if [ "${INPUT_ACTION}" = "destroy" ]; then
+              if [ "${INPUT_DESTROY_CONFIRM}" = "DESTROY_PROD" ]; then
+                echo "- Destroy confirm provided: \`true\`"
+              else
+                echo "- Destroy confirm provided: \`false\`"
+              fi
             fi
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Cleanup sensitive files
         if: always()
         run: |
-          tfvars_file="${{ inputs.tf_dir }}/${{ inputs.tfvars_path }}"
-          rm -f "${tfvars_file}" "${{ inputs.tf_dir }}/tfplan.binary" "${{ inputs.tf_dir }}/tfplan.destroy.binary"
+          tfvars_file="${INPUT_TF_DIR}/${INPUT_TFVARS_PATH}"
+          rm -f "${tfvars_file}" "${INPUT_TF_DIR}/tfplan.binary" "${INPUT_TF_DIR}/tfplan.destroy.binary"

--- a/docs/GCP_RUNBOOK.md
+++ b/docs/GCP_RUNBOOK.md
@@ -635,8 +635,8 @@ Dispatch inputs:
 
 - `action`: `plan` | `apply` | `destroy`
 - `target_ref`: git ref input (must be `main`)
-- `tf_dir`: defaults to `infra/terraform`
-- `tfvars_path`: defaults to `envs/prod.tfvars`
+- `tf_dir`: input is allowlisted to `infra/terraform`
+- `tfvars_path`: input is allowlisted to `envs/prod.tfvars`
 - `destroy_confirm`: must equal `DESTROY_PROD` for destroy
 
 Safety gates:

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -96,6 +96,7 @@ Dispatch usage:
 - `plan`: must be dispatched from `main` with `target_ref=main`.
 - `apply`: must be dispatched from `main` with `target_ref=main`; workflow plans to `tfplan.binary` then applies that plan.
 - `destroy`: same `main` restrictions as apply, plus `destroy_confirm` must equal `DESTROY_PROD`; workflow plans to `tfplan.destroy.binary` then applies that plan.
+- `tf_dir` and `tfvars_path` are allowlisted to `infra/terraform` and `envs/prod.tfvars` to reduce operator and input-injection risk.
 
 Sensitive runtime files (`envs/prod.tfvars` decoded from secret and local plan binaries) are deleted in an `always()` cleanup step.
 


### PR DESCRIPTION
## Summary
- add a new manual-dispatch workflow at `.github/workflows/infra-terraform-ops.yml` with `action=plan|apply|destroy`
- enforce mutating actions from protected `main` only and require `environment: infra-prod`
- enforce typed destroy confirmation (`destroy_confirm=DESTROY_PROD`) before any destroy plan/apply path
- decode `TFVARS_PROD_B64` at runtime with strict permissions, validate non-empty file, and always clean up decoded tfvars + local plan binaries
- update `docs/GCP_RUNBOOK.md` and `infra/terraform/README.md` with setup/usage instructions for the new workflow

## Verification
- `rg -n "workflow_dispatch|TFVARS_PROD_B64|environment: infra-prod|destroy_confirm|DESTROY_PROD|tfplan.destroy.binary|always\(\)|target_ref=main" .github/workflows/infra-terraform-ops.yml docs/GCP_RUNBOOK.md infra/terraform/README.md`
- `git diff --check`

## Manual verification to run in GitHub Actions
1. Dispatch `action=plan` and confirm successful plan.
2. Dispatch `action=apply` with `target_ref != main` and confirm hard fail.
3. Dispatch `action=apply` on `main` and confirm `infra-prod` approval gate and apply-from-plan behavior.
4. Dispatch `action=destroy` with wrong confirmation and confirm hard fail.
5. Dispatch `action=destroy` with `DESTROY_PROD` on `main` and confirm apply-from-destroy-plan behavior.
6. Confirm step summary/logs never expose tfvars payload and cleanup step removes decoded tfvars file.

Closes #193
