### PR TITLE
Task: Fix React hydration mismatch on dashboard (layoutMode + debugMode SSR init)

### DIFF
--- a/frontend/app/components/dashboard/ChatWindow.tsx
+++ b/frontend/app/components/dashboard/ChatWindow.tsx
@@ -131,7 +131,7 @@ export function ChatWindow({
       // Skip the next generic message-driven auto-scroll run so initial render doesn't jump twice.
       skipPostHistoryScrollRef.current = true;
     }
-  }, [loadingHistory]);
+  }, [loadingHistory, scrollToBottom]);
 
   // Keep chat at bottom for live updates after initial history load.
   useLayoutEffect(() => {

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -19,7 +19,6 @@ import { WorkspaceSidebar } from "../components/dashboard/WorkspaceSidebar";
 import { DocumentPicker } from "../components/dashboard/DocumentPicker";
 import { useDashboardState } from "@/lib/hooks/useDashboardState";
 
-const SIDEBAR_WIDTH = "w-72";
 const MAX_DOCUMENTS_PER_WORKSPACE = 20;
 const PdfViewer = dynamic(
   () =>

--- a/frontend/lib/hooks/useDashboardState.ts
+++ b/frontend/lib/hooks/useDashboardState.ts
@@ -26,22 +26,6 @@ export type MobileTab = "pdf" | "chat";
 export type DashboardMode = "documents" | "workspaces";
 export type LayoutMode = "mobile" | "compact" | "desktop";
 
-const getLayoutModeFromWidth = (width: number): LayoutMode => {
-  if (width >= DESKTOP_LAYOUT_MIN_WIDTH) return "desktop";
-  if (width >= COMPACT_LAYOUT_MIN_WIDTH) return "compact";
-  return "mobile";
-};
-
-const getInitialLayoutMode = (): LayoutMode => {
-  if (typeof window === "undefined") return "mobile";
-  return getLayoutModeFromWidth(window.innerWidth);
-};
-
-const getInitialDebugMode = (): boolean => {
-  if (typeof window === "undefined") return false;
-  return window.localStorage.getItem(DEBUG_MODE_STORAGE_KEY) === "true";
-};
-
 interface CitationTarget {
   page: number;
   snippet?: string;
@@ -118,9 +102,9 @@ export function useDashboardState({
   const [highlightPage, setHighlightPage] = useState<number | null>(null);
   const [highlightSnippet, setHighlightSnippet] = useState<string | null>(null);
   const [mobileTab, setMobileTab] = useState<MobileTab>("chat");
-  const [layoutMode, setLayoutMode] = useState<LayoutMode>(getInitialLayoutMode);
+  const [layoutMode, setLayoutMode] = useState<LayoutMode>("mobile");
   const [desktopSidebarCollapsed, setDesktopSidebarCollapsed] = useState(false);
-  const [debugMode, setDebugMode] = useState(getInitialDebugMode);
+  const [debugMode, setDebugMode] = useState(false);
   const [isDemoUser, setIsDemoUser] = useState(false);
   const documentsRef = useRef<Document[]>([]);
 
@@ -200,6 +184,16 @@ export function useDashboardState({
   useEffect(() => {
     documentsRef.current = documents;
   }, [documents]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      setDebugMode(window.localStorage.getItem(DEBUG_MODE_STORAGE_KEY) === "true");
+    } catch {
+      // Keep debug mode disabled if localStorage is unavailable or inaccessible.
+      setDebugMode(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (!selectedDocument) return;


### PR DESCRIPTION
## Summary
- Fix React hydration mismatch on dashboard by avoiding browser-only state initialization during SSR.
- Restore client-specific `debugMode` state from `localStorage` after hydration.
- Remove stale dashboard sidebar-width constant.
- Address `react-hooks/exhaustive-deps` warning in `ChatWindow` by including `scrollToBottom` dependency.

## Issue
Closes #224

## Testing
- Not run in this PR execution path.
